### PR TITLE
Bug/marker hover

### DIFF
--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -61,7 +61,7 @@ const interactPlugin = createInteractPlugin({
 		idProperty: 'id'
 	}],
 	debug: true,
-	interactionModes: ['selectMarker', 'selectFeature'], // e.g. ['selectMarker'], ['selectFeature'], ['placeMarker'], or combinations
+	interactionModes: ['selectMarker', 'placeMarker', 'selectFeature'], // e.g. ['selectMarker'], ['selectFeature'], ['placeMarker'], or combinations
 	// multiSelect: true,
 	contiguous: true,
 	deselectOnClickOutside: true

--- a/demo/js/searchCustomDatasets.js
+++ b/demo/js/searchCustomDatasets.js
@@ -64,7 +64,7 @@ const buildGridrefRequest = (query, crs = 'wgs84') => {
     params.set('gridref', clean)
   }
 
-  return { url: `${process.env.FARMING_API_URL}/gridref?${params}`, options: { method: 'GET' } }
+  return new Request(`${process.env.FARMING_API_URL}/gridref?${params}`)
 }
 
 const parseGridrefResults = (json, query) => {
@@ -101,7 +101,7 @@ const parseGridrefResults = (json, query) => {
 const buildParcelRequest = (query) => {
   const sanitisedQuery = query.replace(/ /g,'')
   const url = `${process.env.FARMING_API_URL}/parcel/{query}`.replace('{query}', encodeURIComponent(sanitisedQuery))
-  return { url, options: { method: 'GET' } }
+  return new Request(url)
 }
 
 const parseParcelResults = (json, query) => {

--- a/demo/js/searchCustomDatasets.js
+++ b/demo/js/searchCustomDatasets.js
@@ -64,7 +64,7 @@ const buildGridrefRequest = (query, crs = 'wgs84') => {
     params.set('gridref', clean)
   }
 
-  return `${process.env.FARMING_API_URL}/gridref?${params}`
+  return { url: `${process.env.FARMING_API_URL}/gridref?${params}`, options: { method: 'GET' } }
 }
 
 const parseGridrefResults = (json, query) => {
@@ -100,8 +100,8 @@ const parseGridrefResults = (json, query) => {
 
 const buildParcelRequest = (query) => {
   const sanitisedQuery = query.replace(/ /g,'')
-  const url = `${process.env.FARMING_API_URL}/parcel/{query}`
-  return url.replace('{query}', encodeURIComponent(sanitisedQuery))
+  const url = `${process.env.FARMING_API_URL}/parcel/{query}`.replace('{query}', encodeURIComponent(sanitisedQuery))
+  return { url, options: { method: 'GET' } }
 }
 
 const parseParcelResults = (json, query) => {

--- a/plugins/interact/src/InteractInit.jsx
+++ b/plugins/interact/src/InteractInit.jsx
@@ -14,7 +14,7 @@ export const InteractInit = ({
   pluginState
 }) => {
   const { interfaceType } = appState
-  const { dispatch, enabled, selectedFeatures, selectionBounds } = pluginState
+  const { dispatch, enabled, selectedFeatures, selectionBounds, interactionModes, layers } = pluginState
   const { eventBus, closeApp } = services
   const { crossHair, mapStyle } = mapState
 
@@ -64,10 +64,10 @@ export const InteractInit = ({
 
   // Notify other components (e.g. Markers) whether interact is active
   useEffect(() => {
-    eventBus.emit('interact:active', { active: enabled })
-  }, [enabled])
+    eventBus.emit('interact:active', { active: enabled, interactionModes })
+  }, [enabled, interactionModes])
 
-  useHoverCursor(mapProvider, enabled, pluginState.interactionModes, pluginState.layers)
+  useHoverCursor(mapProvider, enabled, interactionModes, layers)
 
   // Toggle target marker visibility
   useEffect(() => {

--- a/plugins/interact/src/InteractInit.test.js
+++ b/plugins/interact/src/InteractInit.test.js
@@ -104,6 +104,14 @@ describe('InteractInit', () => {
     expect(cleanupMock).toHaveBeenCalled()
   })
 
+  it('emits interact:active with active state and interactionModes on enable', () => {
+    render(<InteractInit {...props} />)
+    expect(props.services.eventBus.emit).toHaveBeenCalledWith('interact:active', {
+      active: true,
+      interactionModes: props.pluginState.interactionModes
+    })
+  })
+
   it('enables click handling after a macrotask', () => {
     jest.useFakeTimers()
     render(<InteractInit {...props} />)

--- a/plugins/search/src/events/fetchSuggestions.js
+++ b/plugins/search/src/events/fetchSuggestions.js
@@ -11,7 +11,8 @@ const getRequestConfig = async (ds, query, transformRequest) => {
   }
 
   if (ds.buildRequest) {
-    return toRequest(ds.buildRequest(query, () => defaultRequest))
+    const result = ds.buildRequest(query, () => defaultRequest)
+    return result instanceof Request ? result : toRequest(result)
   }
 
   if (transformRequest) {

--- a/plugins/search/src/events/fetchSuggestions.test.js
+++ b/plugins/search/src/events/fetchSuggestions.test.js
@@ -9,7 +9,10 @@ describe('fetchSuggestions', () => {
   beforeEach(() => {
     dispatch.mockClear()
     global.fetch = jest.fn()
-    global.Request = jest.fn((url, options) => ({ url, ...options }))
+    global.Request = jest.fn(function (url, options) {
+      this.url = url
+      if (options) { Object.assign(this, options) }
+    })
     jest.spyOn(console, 'error').mockImplementation(() => {})
   })
 
@@ -186,6 +189,24 @@ describe('fetchSuggestions', () => {
 
     expect(result.results).toEqual(['first'])
     expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  test('uses buildRequest result directly when it returns a Request instance', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({})
+    })
+
+    const datasets = [
+      {
+        buildRequest: (query) => new Request(`/custom/${query}`),
+        parseResults: () => ['z']
+      }
+    ]
+
+    await fetchSuggestions('abc', datasets, dispatch)
+
+    expect(fetch).toHaveBeenCalledWith(expect.objectContaining({ url: '/custom/abc' }))
   })
 
   test('buildRequest can call default request builder', async () => {

--- a/src/App/components/Markers/Markers.jsx
+++ b/src/App/components/Markers/Markers.jsx
@@ -64,12 +64,12 @@ export const Markers = () => {
   const { markers, markerRef } = useMarkers()
   const { symbolRegistry, eventBus } = useService()
 
-  const [interactActive, setInteractActive] = useState(false)
+  const [canSelectMarker, setCanSelectMarker] = useState(false)
   const [selectedMarkers, setSelectedMarkers] = useState([])
   const viewportRef = useRef(null)
 
   useEffect(() => {
-    const handleActive = ({ active }) => setInteractActive(active)
+    const handleActive = ({ active, interactionModes = [] }) => setCanSelectMarker(active && interactionModes.includes('selectMarker'))
     const handleSelectionChange = ({ selectedMarkers: next = [] }) => setSelectedMarkers(next)
     eventBus.on('interact:active', handleActive)
     eventBus.on('interact:selectionchange', handleSelectionChange)
@@ -84,7 +84,7 @@ export const Markers = () => {
     viewportRef.current = document.querySelector('.im-c-viewport')
   }, [])
 
-  useMarkerCursor(markers, interactActive, viewportRef)
+  useMarkerCursor(markers, canSelectMarker, viewportRef)
 
   if (!mapStyle) {
     return undefined

--- a/src/App/components/Markers/Markers.test.jsx
+++ b/src/App/components/Markers/Markers.test.jsx
@@ -202,6 +202,13 @@ describe('Markers', () => {
       expect(viewport.style.cursor).toBe('')
     })
 
+    it('does not track mousemove when interactionModes is absent from payload', () => {
+      const eb = setupCursor({ left: 10, top: 10, right: 50, bottom: 50 })
+      act(() => eb.emit('interact:active', { active: true }))
+      fireMove(20, 20)
+      expect(viewport.style.cursor).toBe('')
+    })
+
     it('does not track mousemove when viewport element is absent', () => {
       document.body.removeChild(viewport)
       const eb = setupCursor({ left: 0, top: 0, right: 50, bottom: 50 })

--- a/src/App/components/Markers/Markers.test.jsx
+++ b/src/App/components/Markers/Markers.test.jsx
@@ -171,8 +171,8 @@ describe('Markers', () => {
       if (viewport.parentNode) document.body.removeChild(viewport)
     })
 
-    const activate = (eb) => act(() => eb.emit('interact:active', { active: true }))
-    const deactivate = (eb) => act(() => eb.emit('interact:active', { active: false }))
+    const activate = (eb) => act(() => eb.emit('interact:active', { active: true, interactionModes: ['selectMarker'] }))
+    const deactivate = (eb) => act(() => eb.emit('interact:active', { active: false, interactionModes: ['selectMarker'] }))
     const fireMove = (clientX, clientY) => act(() => {
       viewport.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX, clientY }))
     })
@@ -189,8 +189,15 @@ describe('Markers', () => {
       return eb
     }
 
-    it('does not track mousemove when interactActive is false', () => {
+    it('does not track mousemove when interact is not active', () => {
       setupCursor({ left: 0, top: 0, right: 50, bottom: 50 })
+      fireMove(20, 20)
+      expect(viewport.style.cursor).toBe('')
+    })
+
+    it('does not track mousemove when selectMarker is not in interactionModes', () => {
+      const eb = setupCursor({ left: 10, top: 10, right: 50, bottom: 50 })
+      act(() => eb.emit('interact:active', { active: true, interactionModes: ['selectFeature'] }))
       fireMove(20, 20)
       expect(viewport.style.cursor).toBe('')
     })

--- a/src/App/hooks/useInterfaceAPI.test.js
+++ b/src/App/hooks/useInterfaceAPI.test.js
@@ -1,0 +1,156 @@
+import { renderHook, act } from '@testing-library/react'
+import { useInterfaceAPI } from './useInterfaceAPI.js'
+import { useApp } from '../store/appContext.js'
+import { useService } from '../store/serviceContext.js'
+
+jest.mock('../store/appContext.js')
+jest.mock('../store/serviceContext.js')
+
+const makeEventBus = () => {
+  const handlers = {}
+  return {
+    on: jest.fn((event, handler) => { handlers[event] = handler }),
+    off: jest.fn(),
+    emit: (event, payload) => handlers[event]?.(payload),
+    _handlers: handlers
+  }
+}
+
+describe('useInterfaceAPI', () => {
+  let mockDispatch, mockEventBus, mockState
+
+  beforeEach(() => {
+    mockDispatch = jest.fn()
+    mockEventBus = makeEventBus()
+    mockState = {
+      hiddenButtons: new Set(),
+      disabledButtons: new Set(),
+      pressedButtons: new Set(),
+      expandedButtons: new Set()
+    }
+
+    useApp.mockReturnValue({ dispatch: mockDispatch, ...mockState })
+    useService.mockReturnValue({ eventBus: mockEventBus })
+  })
+
+  it('dispatches ADD_BUTTON on app:addbutton', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:addbutton', { id: 'btn1', config: { label: 'Test' } }))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'ADD_BUTTON', payload: { id: 'btn1', config: { label: 'Test' } } })
+  })
+
+  it('also dispatches ADD_BUTTON for each menuItem', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:addbutton', {
+      id: 'btn1',
+      config: {
+        label: 'Parent',
+        menuItems: [
+          { id: 'item1', label: 'Item 1' },
+          { id: 'item2', label: 'Item 2' }
+        ]
+      }
+    }))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'ADD_BUTTON', payload: { id: 'btn1', config: expect.objectContaining({ label: 'Parent' }) } })
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'ADD_BUTTON', payload: { id: 'item1', config: { id: 'item1', label: 'Item 1', isMenuItem: true } } })
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'ADD_BUTTON', payload: { id: 'item2', config: { id: 'item2', label: 'Item 2', isMenuItem: true } } })
+  })
+
+  it('dispatches TOGGLE_APP_VISIBLE true on app:visible', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:visible'))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'TOGGLE_APP_VISIBLE', payload: true })
+  })
+
+  it('dispatches TOGGLE_APP_VISIBLE false on app:hidden', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:hidden'))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'TOGGLE_APP_VISIBLE', payload: false })
+  })
+
+  it('dispatches ADD_PANEL on app:addpanel', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:addpanel', { id: 'panel1', config: { title: 'My Panel' } }))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'ADD_PANEL', payload: { id: 'panel1', config: { title: 'My Panel' } } })
+  })
+
+  it('dispatches REMOVE_PANEL on app:removepanel', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:removepanel', 'panel1'))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'REMOVE_PANEL', payload: 'panel1' })
+  })
+
+  it('dispatches OPEN_PANEL on app:showpanel', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:showpanel', 'panel1'))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'OPEN_PANEL', payload: { panelId: 'panel1' } })
+  })
+
+  it('dispatches CLOSE_PANEL on app:hidepanel', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:hidepanel', 'panel1'))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'CLOSE_PANEL', payload: 'panel1' })
+  })
+
+  it('dispatches ADD_CONTROL on app:addcontrol', () => {
+    renderHook(() => useInterfaceAPI())
+    act(() => mockEventBus.emit('app:addcontrol', { id: 'ctrl1', config: { position: 'top-left' } }))
+    expect(mockDispatch).toHaveBeenCalledWith({ type: 'ADD_CONTROL', payload: { id: 'ctrl1', config: { position: 'top-left' } } })
+  })
+
+  describe('handleToggleButtonState', () => {
+    it.each([
+      ['hidden', 'TOGGLE_BUTTON_HIDDEN', 'isHidden'],
+      ['disabled', 'TOGGLE_BUTTON_DISABLED', 'isDisabled'],
+      ['pressed', 'TOGGLE_BUTTON_PRESSED', 'isPressed'],
+      ['expanded', 'TOGGLE_BUTTON_EXPANDED', 'isExpanded']
+    ])('sets %s to explicit boolean value when provided', (prop, actionType, payloadKey) => {
+      renderHook(() => useInterfaceAPI())
+      act(() => mockEventBus.emit('app:togglebuttonstate', { id: 'btn1', prop, value: true }))
+      expect(mockDispatch).toHaveBeenCalledWith({ type: actionType, payload: { id: 'btn1', [payloadKey]: true } })
+
+      mockDispatch.mockClear()
+      act(() => mockEventBus.emit('app:togglebuttonstate', { id: 'btn1', prop, value: false }))
+      expect(mockDispatch).toHaveBeenCalledWith({ type: actionType, payload: { id: 'btn1', [payloadKey]: false } })
+    })
+
+    it.each([
+      ['hidden', 'TOGGLE_BUTTON_HIDDEN', 'isHidden', 'hiddenButtons'],
+      ['disabled', 'TOGGLE_BUTTON_DISABLED', 'isDisabled', 'disabledButtons'],
+      ['pressed', 'TOGGLE_BUTTON_PRESSED', 'isPressed', 'pressedButtons'],
+      ['expanded', 'TOGGLE_BUTTON_EXPANDED', 'isExpanded', 'expandedButtons']
+    ])('toggles %s when no boolean value provided', (prop, actionType, payloadKey, stateKey) => {
+      renderHook(() => useInterfaceAPI())
+
+      // Not in set → toggles to true
+      act(() => mockEventBus.emit('app:togglebuttonstate', { id: 'btn1', prop }))
+      expect(mockDispatch).toHaveBeenCalledWith({ type: actionType, payload: { id: 'btn1', [payloadKey]: true } })
+
+      // Already in set → toggles to false
+      mockDispatch.mockClear()
+      mockState[stateKey].add('btn1')
+      act(() => mockEventBus.emit('app:togglebuttonstate', { id: 'btn1', prop }))
+      expect(mockDispatch).toHaveBeenCalledWith({ type: actionType, payload: { id: 'btn1', [payloadKey]: false } })
+    })
+
+    it('does nothing for unknown prop', () => {
+      renderHook(() => useInterfaceAPI())
+      act(() => mockEventBus.emit('app:togglebuttonstate', { id: 'btn1', prop: 'unknown', value: true }))
+      expect(mockDispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  it('removes all event listeners on unmount', () => {
+    const { unmount } = renderHook(() => useInterfaceAPI())
+    unmount()
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:visible', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:hidden', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:addbutton', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:togglebuttonstate', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:addpanel', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:removepanel', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:showpanel', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:hidepanel', expect.any(Function))
+    expect(mockEventBus.off).toHaveBeenCalledWith('app:addcontrol', expect.any(Function))
+  })
+})


### PR DESCRIPTION
Two loosely related bug fixes.
Search fetchSuggestions fix to accept request object return from dastaset.buildRequest
Corresponding search marker hover only active if interact has selectMarker in modes list
