### PR TITLE
Feature/pattern fill resolution fix

### DIFF
--- a/plugins/beta/datasets/src/adapters/maplibre/layerBuilders.js
+++ b/plugins/beta/datasets/src/adapters/maplibre/layerBuilders.js
@@ -29,14 +29,14 @@ export const addSource = (map, dataset, sourceId) => {
 
 // ─── Fill layer ───────────────────────────────────────────────────────────────
 
-export const addFillLayer = (map, config, layerId, sourceId, sourceLayer, visibility, { mapStyleId, patternRegistry }) => {
+export const addFillLayer = (map, config, layerId, sourceId, sourceLayer, visibility, { mapStyleId, patternRegistry, pixelRatio = 1 }) => {
   if (!layerId || map.getLayer(layerId)) {
     return
   }
   if (!config.fill && !hasPattern(config)) {
     return
   }
-  const patternImageId = hasPattern(config) ? getPatternImageId(config, mapStyleId, patternRegistry) : null
+  const patternImageId = hasPattern(config) ? getPatternImageId(config, mapStyleId, patternRegistry, pixelRatio) : null
   const paint = patternImageId
     ? { 'fill-pattern': patternImageId, 'fill-opacity': config.opacity || 1 }
     : { 'fill-color': getValueForStyle(config.fill, mapStyleId), 'fill-opacity': config.opacity || 1 }
@@ -116,7 +116,7 @@ export const addSublayerLayers = (map, dataset, sublayer, sourceId, sourceLayer,
     addSymbolLayer(map, merged, symbolLayerId, sourceId, sourceLayer, visibility, { mapStyle, symbolRegistry, pixelRatio })
     return
   }
-  addFillLayer(map, merged, fillLayerId, sourceId, sourceLayer, visibility, { mapStyleId, patternRegistry })
+  addFillLayer(map, merged, fillLayerId, sourceId, sourceLayer, visibility, { mapStyleId, patternRegistry, pixelRatio })
   addStrokeLayer(map, merged, strokeLayerId, sourceId, sourceLayer, visibility, mapStyleId)
 }
 
@@ -153,7 +153,7 @@ export const addDatasetLayers = (map, dataset, mapStyle, symbolRegistry, pattern
     return sourceId
   }
 
-  addFillLayer(map, dataset, fillLayerId, sourceId, sourceLayer, visibility, { mapStyleId, patternRegistry })
+  addFillLayer(map, dataset, fillLayerId, sourceId, sourceLayer, visibility, { mapStyleId, patternRegistry, pixelRatio })
   addStrokeLayer(map, dataset, strokeLayerId, sourceId, sourceLayer, visibility, mapStyleId)
   return sourceId
 }

--- a/plugins/beta/datasets/src/adapters/maplibre/maplibreLayerAdapter.js
+++ b/plugins/beta/datasets/src/adapters/maplibre/maplibreLayerAdapter.js
@@ -1,7 +1,7 @@
 import { applyExclusionFilter } from '../../utils/filters.js'
 import { getSourceId, getLayerIds, getSublayerLayerIds, getAllLayerIds } from './layerIds.js'
 import { addDatasetLayers, addSublayerLayers } from './layerBuilders.js'
-import { getPatternConfigs } from './patternImages.js'
+import { getPatternConfigs, hasPattern, getPatternImageId } from './patternImages.js'
 import { getSymbolConfigs, getSymbolImageId } from './symbolImages.js'
 import { mergeSublayer } from '../../utils/mergeSublayer.js'
 import { scaleFactor } from '../../../../../../src/config/appConfig.js'
@@ -119,8 +119,11 @@ export default class MaplibreLayerAdapter {
    * @returns {Promise<void>}
    */
   async onSizeChange (datasets, mapStyle) {
-    await this._mapProvider.registerSymbols(getSymbolConfigs(datasets), mapStyle, this._symbolRegistry)
     const pixelRatio = this._pixelRatio
+    await Promise.all([
+      this._mapProvider.registerSymbols(getSymbolConfigs(datasets), mapStyle, this._symbolRegistry),
+      this._mapProvider.registerPatterns(getPatternConfigs(datasets, this._patternRegistry), mapStyle.id, this._patternRegistry)
+    ])
     datasets.forEach(dataset => {
       getAllLayerIds(dataset).forEach(layerId => {
         if (!this._symbolLayerIds.has(layerId) || !this._map.getLayer(layerId)) { return }
@@ -129,13 +132,29 @@ export default class MaplibreLayerAdapter {
           this._map.setLayoutProperty(layerId, 'icon-image', imageId)
         }
       })
+      if (hasPattern(dataset)) {
+        const { fillLayerId } = getLayerIds(dataset)
+        if (this._map.getLayer(fillLayerId)) {
+          const imageId = getPatternImageId(dataset, mapStyle.id, this._patternRegistry, pixelRatio)
+          if (imageId) {
+            this._map.setPaintProperty(fillLayerId, 'fill-pattern', imageId)
+          }
+        }
+      }
       dataset.sublayers?.forEach(sublayer => {
-        const { symbolLayerId } = getSublayerLayerIds(dataset.id, sublayer.id)
-        if (!this._map.getLayer(symbolLayerId)) { return }
         const merged = mergeSublayer(dataset, sublayer)
-        const imageId = getSymbolImageId(merged, mapStyle, this._symbolRegistry, false, pixelRatio)
-        if (imageId) {
-          this._map.setLayoutProperty(symbolLayerId, 'icon-image', imageId)
+        const { symbolLayerId, fillLayerId } = getSublayerLayerIds(dataset.id, sublayer.id)
+        if (this._map.getLayer(symbolLayerId)) {
+          const imageId = getSymbolImageId(merged, mapStyle, this._symbolRegistry, false, pixelRatio)
+          if (imageId) {
+            this._map.setLayoutProperty(symbolLayerId, 'icon-image', imageId)
+          }
+        }
+        if (hasPattern(merged) && this._map.getLayer(fillLayerId)) {
+          const imageId = getPatternImageId(merged, mapStyle.id, this._patternRegistry, pixelRatio)
+          if (imageId) {
+            this._map.setPaintProperty(fillLayerId, 'fill-pattern', imageId)
+          }
         }
       })
     })

--- a/providers/maplibre/src/maplibreProvider.js
+++ b/providers/maplibre/src/maplibreProvider.js
@@ -333,7 +333,8 @@ export default class MapLibreProvider {
    * @returns {Promise<void>}
    */
   async registerPatterns (patternConfigs, mapStyleId, patternRegistry) {
-    return registerPatterns(this.map, patternConfigs, mapStyleId, patternRegistry)
+    const pixelRatio = (this.map.getPixelRatio() || 1) * (scaleFactor[this.mapSize] || 1)
+    return registerPatterns(this.map, patternConfigs, mapStyleId, patternRegistry, pixelRatio)
   }
 
   // ==========================

--- a/providers/maplibre/src/maplibreProvider.test.js
+++ b/providers/maplibre/src/maplibreProvider.test.js
@@ -280,13 +280,33 @@ describe('MapLibreProvider', () => {
     expect(registerSymbols).toHaveBeenCalledWith(map, [], { id: 'test' }, registry, 1) // (0 || 1) * 1
   })
 
-  test('registerPatterns delegates to utility with map instance', async () => {
+  test('registerPatterns delegates to utility with map instance and pixelRatio', async () => {
     const p = makeProvider()
     await doInitMap(p)
     const configs = [{ fillPattern: 'dot' }]
     const registry = {}
     await p.registerPatterns(configs, 'test', registry)
-    expect(registerPatterns).toHaveBeenCalledWith(map, configs, 'test', registry)
+    expect(registerPatterns).toHaveBeenCalledWith(map, configs, 'test', registry, 1) // getPixelRatio()=1, mapSize unset → 1*1
+  })
+
+  test('registerPatterns computes pixelRatio from getPixelRatio and mapSize scale factor', async () => {
+    const p = makeProvider()
+    await doInitMap(p)
+    map.getPixelRatio.mockReturnValue(2)
+    p.mapSize = 'medium' // scaleFactor['medium'] = 1.5
+    const registry = {}
+    await p.registerPatterns([], 'test', registry)
+    expect(registerPatterns).toHaveBeenCalledWith(map, [], 'test', registry, 3) // 2 * 1.5
+  })
+
+  test('registerPatterns falls back to pixelRatio 1 when getPixelRatio returns 0', async () => {
+    const p = makeProvider()
+    await doInitMap(p)
+    map.getPixelRatio.mockReturnValue(0)
+    p.mapSize = 'small' // scaleFactor['small'] = 1
+    const registry = {}
+    await p.registerPatterns([], 'test', registry)
+    expect(registerPatterns).toHaveBeenCalledWith(map, [], 'test', registry, 1) // (0 || 1) * 1
   })
 
   describe('setHoverCursor', () => {

--- a/providers/maplibre/src/utils/patternImages.js
+++ b/providers/maplibre/src/utils/patternImages.js
@@ -1,4 +1,4 @@
-import { getPatternInnerContent, getPatternImageId, injectColors } from '../../../../src/utils/patternUtils.js'
+import { getPatternInnerContent, getPatternImageId, injectColors, PATTERN_MIN_PIXEL_RATIO } from '../../../../src/utils/patternUtils.js'
 import { getValueForStyle } from '../../../../src/utils/getValueForStyle.js'
 import { rasteriseToImageData } from './rasteriseToImageData.js'
 
@@ -12,15 +12,16 @@ const imageDataCache = new Map()
  * @param {Object} dataset
  * @param {string} mapStyleId
  * @param {Object} patternRegistry
+ * @param {number} pixelRatio
  * @returns {Promise<{ imageId: string, imageData: ImageData }|null>}
  */
-const rasterisePattern = async (dataset, mapStyleId, patternRegistry) => {
+const rasterisePattern = async (dataset, mapStyleId, patternRegistry, pixelRatio) => {
   const innerContent = getPatternInnerContent(dataset, patternRegistry)
   if (!innerContent) {
     return null
   }
 
-  const imageId = getPatternImageId(dataset, mapStyleId, patternRegistry)
+  const imageId = getPatternImageId(dataset, mapStyleId, patternRegistry, pixelRatio)
   if (!imageId) {
     return null
   }
@@ -31,9 +32,12 @@ const rasterisePattern = async (dataset, mapStyleId, patternRegistry) => {
     const bg = getValueForStyle(dataset.fillPatternBackgroundColor, mapStyleId) || 'transparent'
     const colored = injectColors(innerContent, fg, bg)
     const bgRect = `<rect width="16" height="16" fill="${bg}"/>`
-    // pixelRatio: 2 means the map treats this as an 8×8 logical tile — crisp on retina screens.
-    const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">${bgRect}${colored}</svg>`
-    imageData = await rasteriseToImageData(svgString, 16, 16)
+    // effectiveRatio floored at PATTERN_MIN_PIXEL_RATIO keeps the canvas at ≥16px physical so
+    // SVG detail renders crisply. Logical tile size = physicalSize / effectiveRatio = 8px always.
+    const effectiveRatio = Math.max(PATTERN_MIN_PIXEL_RATIO, pixelRatio)
+    const physicalSize = Math.round(8 * effectiveRatio)
+    const svgString = `<svg xmlns="http://www.w3.org/2000/svg" width="${physicalSize}" height="${physicalSize}" viewBox="0 0 16 16">${bgRect}${colored}</svg>`
+    imageData = await rasteriseToImageData(svgString, physicalSize, physicalSize)
     imageDataCache.set(imageId, imageData)
   }
 
@@ -50,21 +54,23 @@ const rasterisePattern = async (dataset, mapStyleId, patternRegistry) => {
  * @param {Object[]} patternConfigs - Flat list of datasets/merged-sublayers with a pattern config
  * @param {string} mapStyleId
  * @param {Object} patternRegistry
+ * @param {number} pixelRatio
  * @returns {Promise<void>}
  */
-export const registerPatterns = async (map, patternConfigs, mapStyleId, patternRegistry) => {
+export const registerPatterns = async (map, patternConfigs, mapStyleId, patternRegistry, pixelRatio) => {
   if (!patternConfigs.length) {
     return
   }
 
+  const effectiveRatio = Math.max(PATTERN_MIN_PIXEL_RATIO, pixelRatio)
   await Promise.all(patternConfigs.map(async (config) => {
-    const imageId = getPatternImageId(config, mapStyleId, patternRegistry)
+    const imageId = getPatternImageId(config, mapStyleId, patternRegistry, pixelRatio)
     if (!imageId || map.hasImage(imageId)) {
       return
     }
-    const result = await rasterisePattern(config, mapStyleId, patternRegistry)
+    const result = await rasterisePattern(config, mapStyleId, patternRegistry, pixelRatio)
     if (result) {
-      map.addImage(result.imageId, result.imageData, { pixelRatio: 2 })
+      map.addImage(result.imageId, result.imageData, { pixelRatio: effectiveRatio })
     }
   }))
 }

--- a/providers/maplibre/src/utils/patternImages.test.js
+++ b/providers/maplibre/src/utils/patternImages.test.js
@@ -45,19 +45,6 @@ describe('registerPatterns — registration', () => {
     expect(map.addImage).not.toHaveBeenCalled()
   })
 
-  it('calls addImage with pixelRatio 2 for a named pattern', async () => {
-    const map = makeMap()
-    const registry = makePatternRegistry()
-    const config = { fillPattern: 'stripes' }
-    await registerPatterns(map, [config], OUTDOOR, registry)
-    expect(map.addImage).toHaveBeenCalledTimes(1)
-    expect(map.addImage).toHaveBeenCalledWith(
-      expect.stringMatching(/^pattern-[a-z0-9]+$/),
-      expect.any(Object),
-      { pixelRatio: 2 }
-    )
-  })
-
   it('calls addImage for an inline fillPatternSvgContent config', async () => {
     const map = makeMap()
     const registry = makePatternRegistry()
@@ -69,10 +56,11 @@ describe('registerPatterns — registration', () => {
   it('skips addImage when image is already registered', async () => {
     const registry = makePatternRegistry()
     const config = { fillPattern: 'stripes' }
+    const pixelRatio = 2
     const { getPatternImageId } = await import('../../../../src/utils/patternUtils.js')
-    const existingId = getPatternImageId(config, OUTDOOR, registry)
+    const existingId = getPatternImageId(config, OUTDOOR, registry, pixelRatio)
     const map = makeMap([existingId])
-    await registerPatterns(map, [config], OUTDOOR, registry)
+    await registerPatterns(map, [config], OUTDOOR, registry, pixelRatio)
     expect(map.addImage).not.toHaveBeenCalled()
   })
 
@@ -101,6 +89,48 @@ describe('registerPatterns — registration', () => {
     }
     await registerPatterns(map, [{ fillPattern: 'stripes' }, { fillPattern: 'dots' }], OUTDOOR, registry)
     expect(map.addImage).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('registerPatterns — pixel ratio', () => {
+  it('encodes effectiveRatio in the image ID and passes it to addImage', async () => {
+    const map = makeMap()
+    const registry = makePatternRegistry()
+    const config = { fillPattern: 'stripes' }
+    await registerPatterns(map, [config], OUTDOOR, registry, 2)
+    expect(map.addImage).toHaveBeenCalledTimes(1)
+    expect(map.addImage).toHaveBeenCalledWith(
+      expect.stringMatching(/^pattern-[a-z0-9]+-2x$/),
+      expect.any(Object),
+      { pixelRatio: 2 }
+    )
+  })
+
+  it('floors effectiveRatio at 2 so low-DPI patterns stay crisp', async () => {
+    const map = makeMap()
+    const registry = makePatternRegistry()
+    const config = { fillPattern: 'stripes' }
+    await registerPatterns(map, [config], OUTDOOR, registry, 1)
+    expect(map.addImage).toHaveBeenCalledWith(
+      expect.stringMatching(/-2x$/),
+      expect.any(Object),
+      { pixelRatio: 2 }
+    )
+  })
+
+  it('produces different image IDs for ratios above the floor', async () => {
+    const map1 = makeMap()
+    const map2 = makeMap()
+    const registry = makePatternRegistry()
+    const config = { fillPattern: 'stripes' }
+    const hiDpi = 3
+    await registerPatterns(map1, [config], OUTDOOR, registry, 2)
+    await registerPatterns(map2, [config], OUTDOOR, registry, hiDpi)
+    const [id2x] = map1.addImage.mock.calls[0]
+    const [id3x] = map2.addImage.mock.calls[0]
+    expect(id2x).not.toBe(id3x)
+    expect(id2x).toMatch(/-2x$/)
+    expect(id3x).toMatch(/-3x$/)
   })
 })
 
@@ -137,12 +167,13 @@ describe('registerPatterns — color resolution and caching', () => {
   it('uses cached ImageData on second call with identical config', async () => {
     const map = makeMap()
     const registry = makePatternRegistry()
-    const config = { fillPattern: 'stripes', fillPatternForegroundColor: '#unique1' }
-    await registerPatterns(map, [config], OUTDOOR, registry)
+    const config = { fillPattern: 'stripes', fillPatternForegroundColor: '#unique2' }
+    const pixelRatio = 2
+    await registerPatterns(map, [config], OUTDOOR, registry, pixelRatio)
     const { getPatternImageId } = await import('../../../../src/utils/patternUtils.js')
-    const imageId = getPatternImageId(config, OUTDOOR, registry)
+    const imageId = getPatternImageId(config, OUTDOOR, registry, pixelRatio)
     const map2 = makeMap([imageId])
-    await registerPatterns(map2, [config], OUTDOOR, registry)
+    await registerPatterns(map2, [config], OUTDOOR, registry, pixelRatio)
     expect(map2.addImage).not.toHaveBeenCalled()
   })
 })

--- a/src/utils/patternUtils.js
+++ b/src/utils/patternUtils.js
@@ -52,21 +52,26 @@ export const getPatternInnerContent = (dataset, patternRegistry) => {
 }
 
 /**
- * Returns a deterministic image ID for a pattern + resolved colour combination.
+ * Returns a deterministic image ID for a pattern + resolved colour + pixel ratio combination.
  *
  * @param {Object} dataset
  * @param {string} mapStyleId
  * @param {Object} patternRegistry
+ * @param {number} [pixelRatio=1]
  * @returns {string|null}
  */
-export const getPatternImageId = (dataset, mapStyleId, patternRegistry) => {
+// Minimum oversampling — keeps 16×16 physical pixels as the floor so patterns remain crisp.
+export const PATTERN_MIN_PIXEL_RATIO = 2
+
+export const getPatternImageId = (dataset, mapStyleId, patternRegistry, pixelRatio = 1) => {
   const innerContent = getPatternInnerContent(dataset, patternRegistry)
   if (!innerContent) {
     return null
   }
   const fg = getValueForStyle(dataset.fillPatternForegroundColor, mapStyleId) || 'black'
   const bg = getValueForStyle(dataset.fillPatternBackgroundColor, mapStyleId) || 'transparent'
-  return `pattern-${hashString(innerContent + fg + bg)}`
+  const effectiveRatio = Math.max(PATTERN_MIN_PIXEL_RATIO, pixelRatio)
+  return `pattern-${hashString(innerContent + fg + bg)}-${effectiveRatio}x`
 }
 
 /**

--- a/src/utils/patternUtils.test.js
+++ b/src/utils/patternUtils.test.js
@@ -103,6 +103,23 @@ describe('getPatternImageId', () => {
     expect(idA).not.toBe(idB)
   })
 
+  test('floors effective ratio at PATTERN_MIN_PIXEL_RATIO so low-DPI ids match 2x', () => {
+    const dataset = { fillPattern: 'dot' }
+    const id1x = getPatternImageId(dataset, 'style-a', mockRegistry, 1)
+    const id2x = getPatternImageId(dataset, 'style-a', mockRegistry, 2)
+    expect(id1x).toBe(id2x)
+    expect(id1x).toMatch(/-2x$/)
+  })
+
+  test('produces different ids for pixelRatios above the floor', () => {
+    const dataset = { fillPattern: 'dot' }
+    const id2x = getPatternImageId(dataset, 'style-a', mockRegistry, 2)
+    const id3x = getPatternImageId(dataset, 'style-a', mockRegistry, 3)
+    expect(id2x).not.toBe(id3x)
+    expect(id2x).toMatch(/-2x$/)
+    expect(id3x).toMatch(/-3x$/)
+  })
+
   test('falls back to "black" foreground and "transparent" background when colours are absent', () => {
     const id = getPatternImageId({ fillPattern: 'dot' }, 'style-a', mockRegistry)
     const idExplicit = getPatternImageId(


### PR DESCRIPTION
Adds the same mapSize re-raster to the pattern fills that we do to symbols. This way patterns take up minimal size but remain sharp no matter what device pixel ratio or map size is used.