### PR TITLE
workerURL support added to mapLibre provider

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -248,6 +248,32 @@ new InteractiveMap('map', {
 })
 ```
 
+#### MapLibre provider options
+
+`maplibreProvider()` accepts an optional config object.
+
+##### `workerUrl`
+**Type:** `string`
+**Default:** `undefined`
+
+URL to a separately hosted MapLibre worker file (`maplibre-gl-csp-worker.js`). Required when running under a Content Security Policy that blocks `blob:` worker URLs — a common restriction on government and enterprise platforms.
+
+When set, MapLibre loads its rendering worker from this URL instead of generating an inline blob, so your CSP only needs `worker-src 'self'` rather than `worker-src blob:`.
+
+The worker file ships with maplibre-gl and must be served from your own origin (copy from `node_modules/maplibre-gl/dist/maplibre-gl-csp-worker.js`).
+
+**ESM:**
+
+```js
+maplibreProvider({ workerUrl: '/your-assets-path/maplibre-gl-csp-worker.js' })
+```
+
+**UMD:**
+
+```js
+defra.maplibreProvider({ workerUrl: '/your-assets-path/maplibre-gl-csp-worker.js' })
+```
+
 ---
 
 ### `mapSize`

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -34,7 +34,8 @@ export default {
       '<rootDir>/plugins/beta/scale-bar',
       '<rootDir>/plugins/beta/use-location',
       '<rootDir>/.docusaurus',
-      '<rootDir>/build/assets/js'
+      '<rootDir>/build/assets/js',
+      '/dist/'
     ],
     transformIgnorePatterns: []
   }]

--- a/providers/maplibre/src/index.js
+++ b/providers/maplibre/src/index.js
@@ -2,6 +2,7 @@
  * @typedef {import('../../../src/types.js').MapProviderDescriptor} MapProviderDescriptor
  * @typedef {import('../../../src/types.js').MapProviderLoadResult} MapProviderLoadResult
  * @typedef {import('../../../src/types.js').MapProviderConfig} MapProviderConfig
+ * @typedef {import('../../../src/types.js').MaplibreProviderConfig} MaplibreProviderConfig
  */
 
 import { getWebGL } from './utils/detectWebgl.js'
@@ -21,7 +22,7 @@ function supportsModernMaplibre () {
 /**
  * Creates a MapLibre provider descriptor for lazy-loading the map provider.
  *
- * @param {Partial<MapProviderConfig>} [config={}] - Optional provider configuration overrides.
+ * @param {MaplibreProviderConfig} [config={}] - Optional provider configuration overrides.
  * @returns {MapProviderDescriptor} The map provider descriptor.
  */
 export default function createMapLibreProvider (config = {}) {
@@ -37,6 +38,11 @@ export default function createMapLibreProvider (config = {}) {
     /** @returns {Promise<MapProviderLoadResult>} */
     load: async () => {
       const mapFramework = await import(/* webpackChunkName: "im-maplibre-framework" */ 'maplibre-gl')
+
+      if (config.workerUrl) {
+        mapFramework.workerUrl = config.workerUrl
+      }
+
       const MapProvider = (await import(/* webpackChunkName: "im-maplibre-provider" */ './maplibreProvider.js')).default
 
       /** @type {MapProviderConfig} */

--- a/providers/maplibre/src/index.test.js
+++ b/providers/maplibre/src/index.test.js
@@ -74,4 +74,22 @@ describe('createMapLibreProvider', () => {
 
     expect(mapProviderConfig).toEqual({ crs: 'EPSG:4326' })
   })
+
+  test('load sets workerUrl on mapFramework when provided', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const { default: createProvider } = await import('./index.js')
+      const { mapFramework } = await createProvider({ workerUrl: '/assets/maplibre-gl-csp-worker.js' }).load()
+
+      expect(mapFramework.workerUrl).toBe('/assets/maplibre-gl-csp-worker.js')
+    })
+  })
+
+  test('load does not set workerUrl on mapFramework when not provided', async () => {
+    await jest.isolateModulesAsync(async () => {
+      const { default: createProvider } = await import('./index.js')
+      const { mapFramework } = await createProvider().load()
+
+      expect(mapFramework.workerUrl).toBeUndefined()
+    })
+  })
 })

--- a/src/types.js
+++ b/src/types.js
@@ -263,6 +263,19 @@
  */
 
 /**
+ * Configuration options for the MapLibre provider.
+ *
+ * @typedef {Object} MaplibreProviderConfig
+ *
+ * @property {string} [workerUrl]
+ * URL to a separately hosted MapLibre worker file (`maplibre-gl-csp-worker.js`).
+ * Required when running under a Content Security Policy that blocks `blob:` worker
+ * URLs. The file ships with maplibre-gl and must be served from your own origin.
+ * When set, MapLibre loads the worker from this URL instead of generating an
+ * inline blob, so your CSP only needs `worker-src 'self'`.
+ */
+
+/**
  * Descriptor for lazy-loading a map provider.
  *
  * @typedef {Object} MapProviderDescriptor


### PR DESCRIPTION
When running on a Content Security Policy that blocks the use of blob requests. MapLibre won't run. This addition allows switching to WorkerURL instead of blob which should then comply with the CSP.