### PR TITLE
IM-224 Ensure datasetDefaults are only applied once

### DIFF
--- a/plugins/beta/datasets/src/DatasetsInit.jsx
+++ b/plugins/beta/datasets/src/DatasetsInit.jsx
@@ -30,11 +30,6 @@ export function DatasetsInit ({ pluginConfig, pluginState, appState, mapState, m
       return
     }
 
-    // Only initialise state if not already set
-    if (!pluginState.datasets) {
-      dispatch({ type: 'SET_DATASETS', payload: { datasets: pluginConfig.datasets, datasetDefaults } })
-    }
-
     const initDatasets = async () => {
       if (!pluginConfig.layerAdapter) {
         throw new Error('datasets plugin: no layerAdapter provided. Import and pass maplibreLayerAdapter or a custom adapter.')
@@ -52,6 +47,7 @@ export function DatasetsInit ({ pluginConfig, pluginState, appState, mapState, m
         mapStyle: mapState.mapStyle,
         mapProvider,
         events: EVENTS,
+        dispatch,
         eventBus
       })
     }

--- a/plugins/beta/datasets/src/datasets.js
+++ b/plugins/beta/datasets/src/datasets.js
@@ -14,6 +14,7 @@ export const createDatasets = ({
   mapStyle,
   mapProvider,
   events,
+  dispatch,
   eventBus
 }) => {
   const { datasets } = pluginConfig
@@ -38,7 +39,7 @@ export const createDatasets = ({
       })
       dynamicSources.set(dataset.id, dynamicSource)
     })
-
+    dispatch({ type: 'SET_DATASETS', payload: { datasets: processedDatasets, datasetDefaults } })
     eventBus.emit('datasets:ready')
   })
 

--- a/plugins/beta/datasets/src/reducer.js
+++ b/plugins/beta/datasets/src/reducer.js
@@ -25,13 +25,13 @@ const initSublayerVisibility = (dataset) => {
 }
 
 const setDatasets = (state, payload) => {
-  const { datasets, datasetDefaults } = payload
-  const datasetsWithDefaults = datasets.map(dataset => initSublayerVisibility(applyDatasetDefaults(dataset, datasetDefaults)))
+  const { datasets } = payload
+  const datasetsWithSublayerVisibility = datasets.map(initSublayerVisibility)
   const menu = payload.menu || datasetsToMenu({ datasets })
-  const { mappedDatasets, orderedDatasets } = mappedDatasetsReducer({ datasets: datasetsWithDefaults })
+  const { mappedDatasets, orderedDatasets } = mappedDatasetsReducer({ datasets: datasetsWithSublayerVisibility })
   return {
     ...state,
-    datasets: datasetsWithDefaults,
+    datasets: datasetsWithSublayerVisibility,
     mappedDatasets,
     orderedDatasets,
     menu


### PR DESCRIPTION
I noticed that datasetDefaults were applied twice, so have refactored so that they get applied once - and moved the dispatch to the createDatasets method - after they have been applied there, so that the reducer doesn't need to re-apply them.