### PR TITLE
OL: Use default renderMode in VectorTileLayer

### DIFF
--- a/providers/beta/openlayers/src/utils/tileLayers.js
+++ b/providers/beta/openlayers/src/utils/tileLayers.js
@@ -93,7 +93,7 @@ export async function createVectorTileLayer (url, transformRequest) {
     projection: CRS,
     tileGrid
   })
-  const layer = new VectorTileLayer({ source, declutter: true, renderMode: 'vector' })
+  const layer = new VectorTileLayer({ source, declutter: true })
 
   stylefunction(layer, styleJson, sourceId, resolutions, spritesJson, sprite.pngUrl)
 
@@ -125,7 +125,7 @@ export async function createOGCVectorTileLayer (url, transformRequest) {
 
   const tileGrid = new TileGrid({ resolutions, origin, tileSize })
   const source = new OGCVectorTile({ url: tilesUrl, format, tileGrid, projection: CRS })
-  const layer = new VectorTileLayer({ source, declutter: true, renderMode: 'vector' })
+  const layer = new VectorTileLayer({ source, declutter: true })
 
   stylefunction(layer, styleJson, sourceId, resolutions, spritesJson, sprite.pngUrl)
 

--- a/providers/beta/openlayers/src/utils/tileLayers.test.js
+++ b/providers/beta/openlayers/src/utils/tileLayers.test.js
@@ -201,9 +201,9 @@ describe('createVectorTileLayer', () => {
     expect(tileLoadFunction).toBeUndefined()
   })
 
-  it('creates VectorTileLayer with source, declutter true, and vector renderMode', async () => {
+  it('creates VectorTileLayer with source and declutter true', async () => {
     await createVectorTileLayer(styleUrl, null)
-    expect(VectorTileLayer).toHaveBeenCalledWith({ source: mockVectorTileSourceInstance, declutter: true, renderMode: 'vector' })
+    expect(VectorTileLayer).toHaveBeenCalledWith({ source: mockVectorTileSourceInstance, declutter: true })
   })
 
   it('applies stylefunction with layer, styleJson, sourceId, resolutions, spritesJson, spritesPngUrl', async () => {


### PR DESCRIPTION
Using 'vector' was causing rendering issues with misaligned tiles at various zoom levels. Removing the prop and using the default 'hybrid' resolves this.

Looks like a base map isn't suitable to be rendered in vector mode, [the docs](https://openlayers.org/en/latest/apidoc/module-ol_layer_VectorTile-VectorTileLayer.html) mention:

> 'vector': Everything is rendered as vectors and the original render order is maintained. Use this mode for improved performance and visual epxerience on vector tile layers with not too many rendered features (e.g. for highlighting a subset of features of another layer with the same source).

You should be able to reproduce it scrolling in and out to zoom, e.g the screenshots are from around here:
`gep.html?map:center=474648.11,409618.08&map:zoom=20`

renderMode: 'vector'
<img width="747" height="651" alt="Screenshot 2026-05-14 at 09 18 02" src="https://github.com/user-attachments/assets/4672d95c-b227-4bc2-92ff-64980f724a2d" />
<img width="853" height="666" alt="Screenshot 2026-05-14 at 08 16 17" src="https://github.com/user-attachments/assets/be538843-96a8-43bd-909f-feaf2c5c2ca9" />


renderMode: 'hybrid'
<img width="727" height="657" alt="Screenshot 2026-05-14 at 09 18 18" src="https://github.com/user-attachments/assets/bc32d573-3eb8-463a-997e-f413da8f0e1f" />
