### PR TITLE
OL: use latest min/max zoom in map state event

### DIFF
--- a/providers/beta/openlayers/src/mapEvents.js
+++ b/providers/beta/openlayers/src/mapEvents.js
@@ -82,8 +82,6 @@ export function attachMapEvents ({
   const debouncers = []
 
   const view = map.getView()
-  const viewMinZoom = view.getMinZoom()
-  const viewMaxZoom = view.getMaxZoom()
 
   const getMapState = () => {
     if (destroyed) {
@@ -95,8 +93,8 @@ export function attachMapEvents ({
       bounds: getBounds(),
       resolution: getResolution(),
       zoom,
-      isAtMaxZoom: zoom + ZOOM_TOLERANCE >= viewMaxZoom,
-      isAtMinZoom: zoom - ZOOM_TOLERANCE <= viewMinZoom
+      isAtMaxZoom: zoom + ZOOM_TOLERANCE >= view.getMaxZoom(),
+      isAtMinZoom: zoom - ZOOM_TOLERANCE <= view.getMinZoom()
     }
   }
 

--- a/providers/beta/openlayers/src/mapEvents.test.js
+++ b/providers/beta/openlayers/src/mapEvents.test.js
@@ -173,6 +173,32 @@ describe('attachMapEvents — render and data events', () => {
   })
 })
 
+describe('attachMapEvents — dynamic zoom bounds', () => {
+  it('isAtMaxZoom is updated in emitted event when view max zoom changes', () => {
+    const { view, eventBus } = setup()
+    view.trigger('change')
+    mockDebounceFns[0].fn()
+    expect(eventBus.emit).toHaveBeenCalledWith(events.MAP_MOVE_END, expect.objectContaining({ isAtMaxZoom: false }))
+
+    eventBus.emit.mockClear()
+    view.getMaxZoom.mockReturnValue(7)
+    mockDebounceFns[0].fn()
+    expect(eventBus.emit).toHaveBeenCalledWith(events.MAP_MOVE_END, expect.objectContaining({ isAtMaxZoom: true }))
+  })
+
+  it('isAtMinZoom is updated in emitted event when view min zoom changes', () => {
+    const { view, eventBus } = setup()
+    view.trigger('change')
+    mockDebounceFns[0].fn()
+    expect(eventBus.emit).toHaveBeenCalledWith(events.MAP_MOVE_END, expect.objectContaining({ isAtMinZoom: false }))
+
+    eventBus.emit.mockClear()
+    view.getMinZoom.mockReturnValue(7)
+    mockDebounceFns[0].fn()
+    expect(eventBus.emit).toHaveBeenCalledWith(events.MAP_MOVE_END, expect.objectContaining({ isAtMinZoom: true }))
+  })
+})
+
 describe('attachMapEvents — remove', () => {
   it('calls cancel on all debouncers', () => {
     const { handles } = setup()


### PR DESCRIPTION
`isAtMaxZoom`/`isAtMinZoom` were captured once at setup so never updated if the zoom constraints changed. 

Now uses the latest on each emit, matching the Esri and MapLibre providers.