### PR TITLE
OL: add renderMode option to map style config

### DIFF
--- a/docs/api/map-style-config.md
+++ b/docs/api/map-style-config.md
@@ -26,6 +26,36 @@ Allows the OpenLayers provider to support raster, standard vector tile, and OGC 
 
 ---
 
+### `renderMode`
+**Type:** `'hybrid' | 'vector'`
+
+> [!NOTE]
+> This property is only relevant when using the **OpenLayers provider** with vector tile styles (standard or `'ogc-vt'`). It is ignored for raster styles and by other providers.
+
+Sets the render mode on the OpenLayers `VectorTileLayer`. When omitted, OpenLayers defaults to `'hybrid'`.
+
+- `'hybrid'` (default) — polygon and line elements are rendered as images, so pixels are scaled during zoom animations. Point symbols and texts are accurately rendered as vectors and can stay upright on rotated views, but get lifted above all polygon and line elements.
+- `'vector'` — everything is rendered as vectors and the original render order is maintained. Use this mode for improved performance and visual experience on vector tile layers with not too many rendered features (e.g. for highlighting a subset of features of another layer with the same source).
+
+```js
+// Standard vector tile
+{
+  id: 'outdoor',
+  url: 'https://raw.githubusercontent.com/OrdnanceSurvey/OS-Vector-Tile-API-Stylesheets/main/OS_VTS_27700_Outdoor.json',
+  renderMode: 'vector'
+}
+
+// OGC vector tile
+{
+  id: 'outdoor-ngd',
+  type: 'ogc-vt',
+  url: 'https://api.os.uk/maps/vector/ngd/ota/v1/collections/ngd-base/styles/27700?key=YOUR_API_KEY',
+  renderMode: 'vector'
+}
+```
+
+---
+
 ### `url`
 **Type:** `string`
 **Required**

--- a/providers/beta/openlayers/src/appEvents.js
+++ b/providers/beta/openlayers/src/appEvents.js
@@ -8,10 +8,10 @@ export function attachAppEvents ({ mapProvider, layer, layerType, transformReque
       const source = createTileSource(mapStyle.url, transformRequest)
       layer.setSource(source)
     } else if (mapStyle.type === 'ogc-vt') {
-      const { layer: newLayer } = await createOGCVectorTileLayer(mapStyle.url, transformRequest)
+      const { layer: newLayer } = await createOGCVectorTileLayer(mapStyle.url, transformRequest, mapStyle)
       map.getLayers().setAt(0, newLayer)
     } else {
-      const { layer: newLayer } = await createVectorTileLayer(mapStyle.url, transformRequest)
+      const { layer: newLayer } = await createVectorTileLayer(mapStyle.url, transformRequest, mapStyle)
       map.getLayers().setAt(0, newLayer)
     }
     eventBus.emit(events.MAP_STYLE_CHANGE, { mapStyleId: mapStyle.id })

--- a/providers/beta/openlayers/src/appEvents.test.js
+++ b/providers/beta/openlayers/src/appEvents.test.js
@@ -79,8 +79,9 @@ describe('attachAppEvents', () => {
 
     it('on MAP_SET_STYLE: creates a vector tile layer and places it at index 0', async () => {
       const { setAt, handlerFor } = makeSetup()
-      await handlerFor(events.MAP_SET_STYLE)({ url: 'https://example.com/styles', id: 'newVts' })
-      expect(createVectorTileLayer).toHaveBeenCalledWith('https://example.com/styles', null)
+      const mapStyle = { url: 'https://example.com/styles', id: 'newVts' }
+      await handlerFor(events.MAP_SET_STYLE)(mapStyle)
+      expect(createVectorTileLayer).toHaveBeenCalledWith(mapStyle.url, null, mapStyle)
       expect(setAt).toHaveBeenCalledWith(0, mockVectorTileLayerInstance)
     })
 

--- a/providers/beta/openlayers/src/openlayersProvider.js
+++ b/providers/beta/openlayers/src/openlayersProvider.js
@@ -47,11 +47,11 @@ export default class OpenLayersProvider {
       source = createTileSource(mapStyle.url, transformRequest)
       tileLayer = new TileLayer({ source })
     } else if (mapStyle.type === 'ogc-vt') {
-      const vectorTile = await createOGCVectorTileLayer(mapStyle.url, transformRequest)
+      const vectorTile = await createOGCVectorTileLayer(mapStyle.url, transformRequest, mapStyle)
       tileLayer = vectorTile.layer
       source = vectorTile.source
     } else {
-      const vectorTile = await createVectorTileLayer(mapStyle.url, transformRequest)
+      const vectorTile = await createVectorTileLayer(mapStyle.url, transformRequest, mapStyle)
       tileLayer = vectorTile.layer
       source = vectorTile.source
     }

--- a/providers/beta/openlayers/src/openlayersProvider.test.js
+++ b/providers/beta/openlayers/src/openlayersProvider.test.js
@@ -125,7 +125,7 @@ describe('OpenLayersProvider', () => {
     it('creates vector tile layer, OL objects, and emits MAP_READY by default', async () => {
       const { provider, eventBus } = makeProvider()
       await provider.initMap(defaultInitConfig)
-      expect(createVectorTileLayer).toHaveBeenCalledWith(defaultInitConfig.mapStyle.url, null)
+      expect(createVectorTileLayer).toHaveBeenCalledWith(defaultInitConfig.mapStyle.url, null, defaultInitConfig.mapStyle)
       expect(attachMapEvents).toHaveBeenCalled()
       expect(attachAppEvents).toHaveBeenCalled()
       expect(eventBus.emit).toHaveBeenCalledWith(events.MAP_READY, expect.objectContaining({

--- a/providers/beta/openlayers/src/utils/tileLayers.js
+++ b/providers/beta/openlayers/src/utils/tileLayers.js
@@ -66,7 +66,7 @@ function fixIconOpacity (styleJson) {
   })
 }
 
-export async function createVectorTileLayer (url, transformRequest) {
+export async function createVectorTileLayer (url, transformRequest, { renderMode } = {}) {
   const styleJson = await fetchWithTransform(url, 'Style', transformRequest).then(r => r.json())
 
   const sourceId = Object.keys(styleJson.sources)[0]
@@ -93,14 +93,14 @@ export async function createVectorTileLayer (url, transformRequest) {
     projection: CRS,
     tileGrid
   })
-  const layer = new VectorTileLayer({ source, declutter: true })
+  const layer = new VectorTileLayer({ source, declutter: true, ...(renderMode && { renderMode }) })
 
   stylefunction(layer, styleJson, sourceId, resolutions, spritesJson, sprite.pngUrl)
 
   return { layer, source }
 }
 
-export async function createOGCVectorTileLayer (url, transformRequest) {
+export async function createOGCVectorTileLayer (url, transformRequest, { renderMode } = {}) {
   const styleJson = await fetchWithTransform(url, 'Style', transformRequest).then(r => r.json())
 
   const sourceId = Object.keys(styleJson.sources)[0]
@@ -125,7 +125,7 @@ export async function createOGCVectorTileLayer (url, transformRequest) {
 
   const tileGrid = new TileGrid({ resolutions, origin, tileSize })
   const source = new OGCVectorTile({ url: tilesUrl, format, tileGrid, projection: CRS })
-  const layer = new VectorTileLayer({ source, declutter: true })
+  const layer = new VectorTileLayer({ source, declutter: true, ...(renderMode && { renderMode }) })
 
   stylefunction(layer, styleJson, sourceId, resolutions, spritesJson, sprite.pngUrl)
 

--- a/providers/beta/openlayers/src/utils/tileLayers.test.js
+++ b/providers/beta/openlayers/src/utils/tileLayers.test.js
@@ -206,6 +206,11 @@ describe('createVectorTileLayer', () => {
     expect(VectorTileLayer).toHaveBeenCalledWith({ source: mockVectorTileSourceInstance, declutter: true })
   })
 
+  it('passes renderMode to VectorTileLayer when provided', async () => {
+    await createVectorTileLayer(styleUrl, null, { renderMode: 'vector' })
+    expect(VectorTileLayer).toHaveBeenCalledWith(expect.objectContaining({ renderMode: 'vector' }))
+  })
+
   it('applies stylefunction with layer, styleJson, sourceId, resolutions, spritesJson, spritesPngUrl', async () => {
     await createVectorTileLayer(styleUrl, null)
     expect(stylefunction).toHaveBeenCalledWith(


### PR DESCRIPTION
Optionally allow renderMode option to be passed through to [VectorTileLayer](https://openlayers.org/en/latest/apidoc/module-ol_layer_VectorTile.html)