### PR TITLE
Screen reader hints

### DIFF
--- a/src/App/components/Hints/Hints.jsx
+++ b/src/App/components/Hints/Hints.jsx
@@ -17,7 +17,7 @@ import { htmlToPlainText } from '../../../utils/htmlToPlainText.js'
 // eslint-disable-next-line camelcase, react/jsx-pascal-case
 // sonarjs/disable-next-line function-name
 export const Hints = () => {
-  const { id, keyboardHintText } = useConfig()
+  const { id, keyboardHintText, enableMoveControls, moveControlsHintText } = useConfig()
   const { hints } = useService()
   const { layoutRefs } = useApp()
   const [activeHint, setActiveHint] = useState(null)
@@ -32,6 +32,11 @@ export const Hints = () => {
     return null
   }
 
+  // Composed at render time so overriding one text doesn't drop the other.
+  const keyboardDescriptionHtml = enableMoveControls
+    ? `${keyboardHintText} ${moveControlsHintText}`
+    : keyboardHintText
+
   return createPortal(
     <div className='im-o-hints'>
       <div id={`${id}-hints`} className='im-c-hints'>
@@ -45,7 +50,7 @@ export const Hints = () => {
       <div
         id={`${id}-keyboard-desc`}
         className='im-u-visually-hidden'
-        dangerouslySetInnerHTML={{ __html: htmlToPlainText(keyboardHintText) }}
+        dangerouslySetInnerHTML={{ __html: htmlToPlainText(keyboardDescriptionHtml) }}
       />
     </div>,
     layoutRefs.mainRef.current

--- a/src/App/components/KeyboardHelp/KeyboardHelp.jsx
+++ b/src/App/components/KeyboardHelp/KeyboardHelp.jsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import { useConfig } from '../../store/configContext'
 import { useApp } from '../../store/appContext.js'
-import { getKeyboardShortcuts } from '../../registry/keyboardShortcutRegistry.js'
 import { Tabs } from '../Tabs/Tabs.jsx'
 
 const ShortcutList = ({ items }) => (
@@ -42,8 +41,8 @@ const getDefaultTab = (groupEntries, context) => {
 // sonarjs/disable-next-line function-name
 export const KeyboardHelp = ({ context = 'viewport' }) => { // NOSONAR: project does not use PropTypes
   const appConfig = useConfig()
-  const { listboxIsActive } = useApp()
-  const allShortcuts = getKeyboardShortcuts(appConfig)
+  const { listboxIsActive, keyboardShortcutRegistry } = useApp()
+  const allShortcuts = keyboardShortcutRegistry.getKeyboardShortcuts(appConfig)
   const shortcuts = listboxIsActive
     ? allShortcuts
     : allShortcuts.filter(s => s.context !== 'listbox')

--- a/src/App/components/KeyboardHelp/KeyboardHelp.test.jsx
+++ b/src/App/components/KeyboardHelp/KeyboardHelp.test.jsx
@@ -2,13 +2,10 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { KeyboardHelp } from './KeyboardHelp'
-import { getKeyboardShortcuts } from '../../registry/keyboardShortcutRegistry.js'
 import { useConfig } from '../../store/configContext'
 import { useApp } from '../../store/appContext.js'
 
-jest.mock('../../registry/keyboardShortcutRegistry.js', () => ({
-  getKeyboardShortcuts: jest.fn()
-}))
+const getKeyboardShortcuts = jest.fn()
 
 jest.mock('../../store/configContext', () => ({
   useConfig: jest.fn()
@@ -40,7 +37,7 @@ const GLOBAL_SHORTCUTS = [
 
 beforeEach(() => {
   useConfig.mockReturnValue({})
-  useApp.mockReturnValue({ listboxIsActive: false })
+  useApp.mockReturnValue({ listboxIsActive: false, keyboardShortcutRegistry: { getKeyboardShortcuts } })
 })
 
 afterEach(() => {
@@ -79,7 +76,7 @@ describe('KeyboardHelp — tabs', () => {
   const allShortcuts = [...GLOBAL_SHORTCUTS, ...VIEWPORT_SHORTCUTS, ...LISTBOX_SHORTCUTS]
 
   beforeEach(() => {
-    useApp.mockReturnValue({ listboxIsActive: true })
+    useApp.mockReturnValue({ listboxIsActive: true, keyboardShortcutRegistry: { getKeyboardShortcuts } })
   })
 
   it('renders a tab for each group when listboxIsActive is true', () => {

--- a/src/App/components/Viewport/Viewport.jsx
+++ b/src/App/components/Viewport/Viewport.jsx
@@ -18,7 +18,7 @@ import { Markers } from '../Markers/Markers'
 // eslint-disable-next-line camelcase, react/jsx-pascal-case
 // sonarjs/disable-next-line function-name
 export const Viewport = () => {
-  const { id, mapProvider, mapLabel, keyboardHintText } = useConfig()
+  const { id, mapProvider, mapLabel, keyboardHintText, focusOnMount } = useConfig()
   const { mode, previousMode, layoutRefs, safeZoneInset, dispatch } = useApp()
   const { mapSize } = useMap()
   const { eventBus, hints } = useService()
@@ -61,6 +61,13 @@ export const Viewport = () => {
       layoutRefs.viewportRef?.current.focus()
     }
   }, [mode])
+
+  // Focus the viewport on mount when opened by a genuine launcher click (see InteractiveMap.js's _handleButtonClick), never on an auto-load or resize.
+  useEffect(() => {
+    if (focusOnMount) {
+      layoutRefs.viewportRef?.current.focus()
+    }
+  }, [])
 
   return (
     <>

--- a/src/App/components/Viewport/Viewport.test.jsx
+++ b/src/App/components/Viewport/Viewport.test.jsx
@@ -115,6 +115,17 @@ describe('Viewport rendering', () => {
     onViewportFocusChange(false)
     expect(hints.dismiss).toHaveBeenCalled()
   })
+
+  it('focuses the viewport on mount when focusOnMount is true', () => {
+    useConfig.mockReturnValueOnce({ ...useConfig(), focusOnMount: true })
+    const { viewport } = renderViewport()
+    expect(viewport).toHaveFocus()
+  })
+
+  it('does not focus the viewport on mount when focusOnMount is false', () => {
+    renderViewport()
+    expect(viewportEl).not.toHaveFocus()
+  })
 })
 
 describe('Viewport interactions', () => {

--- a/src/App/initialiseApp.js
+++ b/src/App/initialiseApp.js
@@ -5,7 +5,7 @@ import { createButtonRegistry } from './registry/buttonRegistry.js'
 import { createPanelRegistry } from './registry/panelRegistry.js'
 import { createControlRegistry } from './registry/controlRegistry.js'
 import { createPluginRegistry } from './registry/pluginRegistry.js'
-import { setProviderSupportedShortcuts } from './registry/keyboardShortcutRegistry.js'
+import { createKeyboardShortcutRegistry } from './registry/keyboardShortcutRegistry.js'
 import { mergeManifests } from './registry/mergeManifests.js'
 import { App } from './App.jsx'
 
@@ -19,13 +19,15 @@ const getOrCreateRegistries = (rootElement) => {
     const buttonRegistry = createButtonRegistry()
     const panelRegistry = createPanelRegistry()
     const controlRegistry = createControlRegistry()
+    const keyboardShortcutRegistry = createKeyboardShortcutRegistry()
     const pluginRegistry = createPluginRegistry({
       registerButton: buttonRegistry.registerButton,
       registerPanel: panelRegistry.registerPanel,
-      registerControl: controlRegistry.registerControl
+      registerControl: controlRegistry.registerControl,
+      registerKeyboardShortcut: keyboardShortcutRegistry.registerKeyboardShortcut
     })
 
-    registries = { buttonRegistry, panelRegistry, controlRegistry, pluginRegistry }
+    registries = { buttonRegistry, panelRegistry, controlRegistry, pluginRegistry, keyboardShortcutRegistry }
     registryMap.set(rootElement, registries)
   }
   return registries
@@ -70,14 +72,14 @@ export async function initialiseApp (rootElement, {
     mapProviderMap.set(rootElement, mapProvider)
   }
 
+  // Reuse or create registries (persist across app open/close cycles)
+  const { buttonRegistry, panelRegistry, controlRegistry, pluginRegistry, keyboardShortcutRegistry } = getOrCreateRegistries(rootElement)
+  const { registerPlugin } = pluginRegistry
+
   // Register provider-supported shortcuts
   if (mapProvider.capabilities?.supportedShortcuts) {
-    setProviderSupportedShortcuts(mapProvider.capabilities.supportedShortcuts)
+    keyboardShortcutRegistry.setProviderSupportedShortcuts(mapProvider.capabilities.supportedShortcuts)
   }
-
-  // Reuse or create registries (persist across app open/close cycles)
-  const { buttonRegistry, panelRegistry, controlRegistry, pluginRegistry } = getOrCreateRegistries(rootElement)
-  const { registerPlugin } = pluginRegistry
 
   // Clear previous plugins (but keep runtime additions)
   pluginRegistry.clear()
@@ -121,6 +123,7 @@ export async function initialiseApp (rootElement, {
     panelRegistry={panelRegistry}
     controlRegistry={controlRegistry}
     pluginRegistry={pluginRegistry}
+    keyboardShortcutRegistry={keyboardShortcutRegistry}
     mapProvider={mapProvider}
               />)
 

--- a/src/App/initialiseApp.test.js
+++ b/src/App/initialiseApp.test.js
@@ -3,7 +3,6 @@ import { initialiseApp } from './initialiseApp.js'
 import { createRoot } from 'react-dom/client'
 import { EVENTS as events } from '../config/events.js'
 import { createMockRegistries } from '../test-utils.js'
-import { setProviderSupportedShortcuts } from './registry/keyboardShortcutRegistry.js'
 
 // --------------------------------------------------
 // Shared mocks
@@ -48,7 +47,7 @@ jest.mock('./registry/pluginRegistry.js', () => ({
 }))
 
 jest.mock('./registry/keyboardShortcutRegistry.js', () => ({
-  setProviderSupportedShortcuts: jest.fn()
+  createKeyboardShortcutRegistry: jest.fn(() => mockRegistries.keyboardShortcutRegistry)
 }))
 
 jest.mock('./registry/mergeManifests.js', () => ({
@@ -179,6 +178,19 @@ describe('initialiseApp', () => {
 
     await initApp()
 
-    expect(setProviderSupportedShortcuts).not.toHaveBeenCalled()
+    expect(mockRegistries.keyboardShortcutRegistry.setProviderSupportedShortcuts).not.toHaveBeenCalled()
+  })
+
+  test('registers provider-supported shortcuts on the per-instance registry', async () => {
+    await initApp()
+
+    expect(mockRegistries.keyboardShortcutRegistry.setProviderSupportedShortcuts).toHaveBeenCalledWith(['ctrl+a'])
+  })
+
+  test('passes keyboardShortcutRegistry through to the rendered App', async () => {
+    await initApp()
+
+    const rendered = createRoot.mock.results[0].value.render.mock.calls[0][0]
+    expect(rendered.props.keyboardShortcutRegistry).toBe(mockRegistries.keyboardShortcutRegistry)
   })
 })

--- a/src/App/layout/Layout.jsx
+++ b/src/App/layout/Layout.jsx
@@ -16,7 +16,7 @@ import { getMapThemeVars } from '../../config/mapTheme.js'
 // eslint-disable-next-line camelcase, react/jsx-pascal-case
 // sonarjs/disable-next-line function-name
 export const Layout = () => {
-  const { id } = useConfig()
+  const { id, mapLabel, mapHintText } = useConfig()
   const { breakpoint, interfaceType, preferredColorScheme, layoutRefs, isLayoutReady, hasExclusiveControl, isFullscreen } = useApp()
   const { mapStyle } = useMap()
 
@@ -37,6 +37,8 @@ export const Layout = () => {
       style={{ backgroundColor: mapStyle?.backgroundColor || undefined, ...getMapThemeVars(mapStyle) }}
       ref={layoutRefs.appContainerRef}
     >
+      {/* Leads with mapLabel so screen reader users can tell multiple maps on a page apart. */}
+      <div className='im-u-visually-hidden'>{mapLabel}. {mapHintText}</div>
       <Viewport />
       <div className={`im-o-app__overlay${isLayoutReady ? '' : ' im-o-app__overlay--not-ready'}`}>
         <div className='im-o-app__side' ref={layoutRefs.sideRef}>

--- a/src/App/registry/keyboardShortcutRegistry.js
+++ b/src/App/registry/keyboardShortcutRegistry.js
@@ -3,7 +3,7 @@ import { coreShortcuts } from '../controls/keyboardShortcuts.js'
 
 // State is passed in explicitly, rather than held at module scope, so each map instance gets its own registry and can't leak shortcuts or provider support into another map's help panel.
 
-export const registerKeyboardShortcut = (state, { shortcut }) => {
+const _registerKeyboardShortcut = (state, { shortcut }) => {
   const { pluginShortcutHelp, pluginShortcutIds } = state
   if (pluginShortcutIds.has(shortcut.id)) {
     pluginShortcutHelp[pluginShortcutHelp.findIndex(s => s.id === shortcut.id)] = shortcut
@@ -13,11 +13,11 @@ export const registerKeyboardShortcut = (state, { shortcut }) => {
   }
 }
 
-export const setProviderSupportedShortcuts = (state, ids = []) => {
+const _setProviderSupportedShortcuts = (state, ids = []) => {
   state.providerSupportedIds = new Set(ids)
 }
 
-export const getKeyboardShortcuts = (state, appConfig = {}) => {
+const _getKeyboardShortcuts = (state, appConfig = {}) => {
   const filteredCore = coreShortcuts.filter(s => {
     // Must be supported by provider
     if (!state.providerSupportedIds.has(s.id)) {
@@ -47,8 +47,8 @@ export function createKeyboardShortcutRegistry () {
   }
 
   return {
-    registerKeyboardShortcut: (args) => registerKeyboardShortcut(state, args),
-    setProviderSupportedShortcuts: (ids) => setProviderSupportedShortcuts(state, ids),
-    getKeyboardShortcuts: (appConfig) => getKeyboardShortcuts(state, appConfig)
+    registerKeyboardShortcut: (args) => _registerKeyboardShortcut(state, args),
+    setProviderSupportedShortcuts: (ids) => _setProviderSupportedShortcuts(state, ids),
+    getKeyboardShortcuts: (appConfig) => _getKeyboardShortcuts(state, appConfig)
   }
 }

--- a/src/App/registry/keyboardShortcutRegistry.js
+++ b/src/App/registry/keyboardShortcutRegistry.js
@@ -1,15 +1,10 @@
 // src/core/registry/keyboardShortcutRegistry.js
 import { coreShortcuts } from '../controls/keyboardShortcuts.js'
 
-// Stores the actual shortcut objects in insertion order
-const pluginShortcutHelp = []
+// State is passed in explicitly, rather than held at module scope, so each map instance gets its own registry and can't leak shortcuts or provider support into another map's help panel.
 
-// Tracks only IDs for O(1) duplicate detection
-const pluginShortcutIds = new Set()
-
-let providerSupportedIds = new Set()
-
-export const registerKeyboardShortcut = ({ shortcut }) => {
+export const registerKeyboardShortcut = (state, { shortcut }) => {
+  const { pluginShortcutHelp, pluginShortcutIds } = state
   if (pluginShortcutIds.has(shortcut.id)) {
     pluginShortcutHelp[pluginShortcutHelp.findIndex(s => s.id === shortcut.id)] = shortcut
   } else {
@@ -18,14 +13,14 @@ export const registerKeyboardShortcut = ({ shortcut }) => {
   }
 }
 
-export const setProviderSupportedShortcuts = (ids = []) => {
-  providerSupportedIds = new Set(ids)
+export const setProviderSupportedShortcuts = (state, ids = []) => {
+  state.providerSupportedIds = new Set(ids)
 }
 
-export const getKeyboardShortcuts = (appConfig = {}) => {
+export const getKeyboardShortcuts = (state, appConfig = {}) => {
   const filteredCore = coreShortcuts.filter(s => {
     // Must be supported by provider
-    if (!providerSupportedIds.has(s.id)) {
+    if (!state.providerSupportedIds.has(s.id)) {
       return false
     }
     // Check requiredConfig - all specified config values must be truthy
@@ -37,6 +32,23 @@ export const getKeyboardShortcuts = (appConfig = {}) => {
 
   return [
     ...filteredCore, // supported core shortcuts
-    ...pluginShortcutHelp // plugin-defined shortcuts (deduped)
+    ...state.pluginShortcutHelp // plugin-defined shortcuts (deduped)
   ]
+}
+
+// One instance per map — see initialiseApp.js's getOrCreateRegistries.
+export function createKeyboardShortcutRegistry () {
+  const state = {
+    // Stores the actual shortcut objects in insertion order
+    pluginShortcutHelp: [],
+    // Tracks only IDs for O(1) duplicate detection
+    pluginShortcutIds: new Set(),
+    providerSupportedIds: new Set()
+  }
+
+  return {
+    registerKeyboardShortcut: (args) => registerKeyboardShortcut(state, args),
+    setProviderSupportedShortcuts: (ids) => setProviderSupportedShortcuts(state, ids),
+    getKeyboardShortcuts: (appConfig) => getKeyboardShortcuts(state, appConfig)
+  }
 }

--- a/src/App/registry/keyboardShortcutRegistry.test.js
+++ b/src/App/registry/keyboardShortcutRegistry.test.js
@@ -3,7 +3,14 @@ describe('keyboardShortcutRegistry', () => {
   let registerKeyboardShortcut
   let setProviderSupportedShortcuts
   let getKeyboardShortcuts
+  let createKeyboardShortcutRegistry
   let coreShortcutsMock
+
+  const emptyState = () => ({
+    pluginShortcutHelp: [],
+    pluginShortcutIds: new Set(),
+    providerSupportedIds: new Set()
+  })
 
   beforeEach(() => {
     jest.resetModules()
@@ -20,43 +27,49 @@ describe('keyboardShortcutRegistry', () => {
     registerKeyboardShortcut = module.registerKeyboardShortcut
     setProviderSupportedShortcuts = module.setProviderSupportedShortcuts
     getKeyboardShortcuts = module.getKeyboardShortcuts
+    createKeyboardShortcutRegistry = module.createKeyboardShortcutRegistry
   })
 
   test('registerKeyboardShortcut should add a plugin shortcut', () => {
+    const state = emptyState()
     const shortcut = { id: 'pluginShortcut', description: 'Plugin Shortcut' }
-    registerKeyboardShortcut({ shortcut }) // Pass { shortcut }
-    const shortcuts = getKeyboardShortcuts()
+    registerKeyboardShortcut(state, { shortcut })
+    const shortcuts = getKeyboardShortcuts(state)
     expect(shortcuts).toContain(shortcut)
   })
 
   test('registerKeyboardShortcut updates an existing shortcut when re-registered with the same id', () => {
+    const state = emptyState()
     const shortcut = { id: 'duplicate', description: 'First' }
     const updatedShortcut = { id: 'duplicate', description: 'Second' }
-    registerKeyboardShortcut({ shortcut })
-    registerKeyboardShortcut({ shortcut: updatedShortcut })
-    const shortcuts = getKeyboardShortcuts()
+    registerKeyboardShortcut(state, { shortcut })
+    registerKeyboardShortcut(state, { shortcut: updatedShortcut })
+    const shortcuts = getKeyboardShortcuts(state)
     expect(shortcuts).toContain(updatedShortcut)
     expect(shortcuts).not.toContain(shortcut)
     expect(shortcuts.filter(s => s.id === 'duplicate')).toHaveLength(1)
   })
 
   test('setProviderSupportedShortcuts should filter core shortcuts', () => {
-    setProviderSupportedShortcuts(['copy'])
-    const shortcuts = getKeyboardShortcuts()
+    const state = emptyState()
+    setProviderSupportedShortcuts(state, ['copy'])
+    const shortcuts = getKeyboardShortcuts(state)
     expect(shortcuts).toEqual([{ id: 'copy', description: 'Copy' }])
   })
 
   test('setProviderSupportedShortcuts with no argument defaults to empty set', () => {
-    setProviderSupportedShortcuts() // no arguments
-    const shortcuts = getKeyboardShortcuts()
+    const state = emptyState()
+    setProviderSupportedShortcuts(state) // no ids argument
+    const shortcuts = getKeyboardShortcuts(state)
     expect(shortcuts).toEqual([]) // default empty
   })
 
   test('getKeyboardShortcuts should merge core and plugin shortcuts', () => {
-    setProviderSupportedShortcuts(['copy'])
+    const state = emptyState()
+    setProviderSupportedShortcuts(state, ['copy'])
     const pluginShortcut = { id: 'plugin', description: 'Plugin' }
-    registerKeyboardShortcut({ shortcut: pluginShortcut })
-    const shortcuts = getKeyboardShortcuts()
+    registerKeyboardShortcut(state, { shortcut: pluginShortcut })
+    const shortcuts = getKeyboardShortcuts(state)
     expect(shortcuts).toEqual([
       { id: 'copy', description: 'Copy' },
       pluginShortcut
@@ -64,8 +77,9 @@ describe('keyboardShortcutRegistry', () => {
   })
 
   test('setProviderSupportedShortcuts with empty array returns no core shortcuts', () => {
-    setProviderSupportedShortcuts([])
-    const shortcuts = getKeyboardShortcuts()
+    const state = emptyState()
+    setProviderSupportedShortcuts(state, [])
+    const shortcuts = getKeyboardShortcuts(state)
     expect(shortcuts).toEqual([])
   })
 
@@ -78,22 +92,58 @@ describe('keyboardShortcutRegistry', () => {
       ]
     }))
     const module = require('./keyboardShortcutRegistry.js')
-    module.setProviderSupportedShortcuts(['always', 'conditional'])
+    const state = emptyState()
+    module.setProviderSupportedShortcuts(state, ['always', 'conditional'])
 
     // Without config, conditional shortcut is excluded
-    expect(module.getKeyboardShortcuts()).toEqual([
+    expect(module.getKeyboardShortcuts(state)).toEqual([
       { id: 'always', description: 'Always shown' }
     ])
 
     // With config false, conditional shortcut is excluded
-    expect(module.getKeyboardShortcuts({ featureEnabled: false })).toEqual([
+    expect(module.getKeyboardShortcuts(state, { featureEnabled: false })).toEqual([
       { id: 'always', description: 'Always shown' }
     ])
 
     // With config true, conditional shortcut is included
-    expect(module.getKeyboardShortcuts({ featureEnabled: true })).toEqual([
+    expect(module.getKeyboardShortcuts(state, { featureEnabled: true })).toEqual([
       { id: 'always', description: 'Always shown' },
       { id: 'conditional', description: 'Conditional', requiredConfig: ['featureEnabled'] }
     ])
+  })
+
+  describe('createKeyboardShortcutRegistry', () => {
+    test('registers and lists a plugin shortcut through the factory API', () => {
+      const registry = createKeyboardShortcutRegistry()
+      registry.setProviderSupportedShortcuts(['copy'])
+      const shortcut = { id: 'pluginShortcut', description: 'Plugin Shortcut' }
+      registry.registerKeyboardShortcut({ shortcut })
+
+      expect(registry.getKeyboardShortcuts()).toEqual([
+        { id: 'copy', description: 'Copy' },
+        shortcut
+      ])
+    })
+
+    test('two registry instances are fully isolated from each other', () => {
+      // This is the multi-map-on-a-page scenario: a shortcut registered by one map
+      // (e.g. a plugin) must never leak into another map's help panel, and each map's
+      // provider-supported-shortcuts filtering must stay independent.
+      const registryA = createKeyboardShortcutRegistry()
+      const registryB = createKeyboardShortcutRegistry()
+
+      registryA.setProviderSupportedShortcuts(['copy'])
+      registryA.registerKeyboardShortcut({ shortcut: { id: 'onlyOnA', description: 'Only on A' } })
+
+      registryB.setProviderSupportedShortcuts(['paste'])
+
+      expect(registryA.getKeyboardShortcuts()).toEqual([
+        { id: 'copy', description: 'Copy' },
+        { id: 'onlyOnA', description: 'Only on A' }
+      ])
+      expect(registryB.getKeyboardShortcuts()).toEqual([
+        { id: 'paste', description: 'Paste' }
+      ])
+    })
   })
 })

--- a/src/App/registry/keyboardShortcutRegistry.test.js
+++ b/src/App/registry/keyboardShortcutRegistry.test.js
@@ -1,16 +1,7 @@
 // src/core/registry/keyboardShortcutRegistry.test.js
-describe('keyboardShortcutRegistry', () => {
-  let registerKeyboardShortcut
-  let setProviderSupportedShortcuts
-  let getKeyboardShortcuts
+describe('createKeyboardShortcutRegistry', () => {
   let createKeyboardShortcutRegistry
   let coreShortcutsMock
-
-  const emptyState = () => ({
-    pluginShortcutHelp: [],
-    pluginShortcutIds: new Set(),
-    providerSupportedIds: new Set()
-  })
 
   beforeEach(() => {
     jest.resetModules()
@@ -23,64 +14,55 @@ describe('keyboardShortcutRegistry', () => {
       coreShortcuts: coreShortcutsMock
     }))
 
-    const module = require('./keyboardShortcutRegistry.js')
-    registerKeyboardShortcut = module.registerKeyboardShortcut
-    setProviderSupportedShortcuts = module.setProviderSupportedShortcuts
-    getKeyboardShortcuts = module.getKeyboardShortcuts
-    createKeyboardShortcutRegistry = module.createKeyboardShortcutRegistry
+    createKeyboardShortcutRegistry = require('./keyboardShortcutRegistry.js').createKeyboardShortcutRegistry
   })
 
   test('registerKeyboardShortcut should add a plugin shortcut', () => {
-    const state = emptyState()
+    const registry = createKeyboardShortcutRegistry()
     const shortcut = { id: 'pluginShortcut', description: 'Plugin Shortcut' }
-    registerKeyboardShortcut(state, { shortcut })
-    const shortcuts = getKeyboardShortcuts(state)
-    expect(shortcuts).toContain(shortcut)
+    registry.registerKeyboardShortcut({ shortcut })
+    expect(registry.getKeyboardShortcuts()).toContain(shortcut)
   })
 
   test('registerKeyboardShortcut updates an existing shortcut when re-registered with the same id', () => {
-    const state = emptyState()
+    const registry = createKeyboardShortcutRegistry()
     const shortcut = { id: 'duplicate', description: 'First' }
     const updatedShortcut = { id: 'duplicate', description: 'Second' }
-    registerKeyboardShortcut(state, { shortcut })
-    registerKeyboardShortcut(state, { shortcut: updatedShortcut })
-    const shortcuts = getKeyboardShortcuts(state)
+    registry.registerKeyboardShortcut({ shortcut })
+    registry.registerKeyboardShortcut({ shortcut: updatedShortcut })
+    const shortcuts = registry.getKeyboardShortcuts()
     expect(shortcuts).toContain(updatedShortcut)
     expect(shortcuts).not.toContain(shortcut)
     expect(shortcuts.filter(s => s.id === 'duplicate')).toHaveLength(1)
   })
 
   test('setProviderSupportedShortcuts should filter core shortcuts', () => {
-    const state = emptyState()
-    setProviderSupportedShortcuts(state, ['copy'])
-    const shortcuts = getKeyboardShortcuts(state)
-    expect(shortcuts).toEqual([{ id: 'copy', description: 'Copy' }])
+    const registry = createKeyboardShortcutRegistry()
+    registry.setProviderSupportedShortcuts(['copy'])
+    expect(registry.getKeyboardShortcuts()).toEqual([{ id: 'copy', description: 'Copy' }])
   })
 
   test('setProviderSupportedShortcuts with no argument defaults to empty set', () => {
-    const state = emptyState()
-    setProviderSupportedShortcuts(state) // no ids argument
-    const shortcuts = getKeyboardShortcuts(state)
-    expect(shortcuts).toEqual([]) // default empty
+    const registry = createKeyboardShortcutRegistry()
+    registry.setProviderSupportedShortcuts() // no ids argument
+    expect(registry.getKeyboardShortcuts()).toEqual([]) // default empty
   })
 
   test('getKeyboardShortcuts should merge core and plugin shortcuts', () => {
-    const state = emptyState()
-    setProviderSupportedShortcuts(state, ['copy'])
+    const registry = createKeyboardShortcutRegistry()
+    registry.setProviderSupportedShortcuts(['copy'])
     const pluginShortcut = { id: 'plugin', description: 'Plugin' }
-    registerKeyboardShortcut(state, { shortcut: pluginShortcut })
-    const shortcuts = getKeyboardShortcuts(state)
-    expect(shortcuts).toEqual([
+    registry.registerKeyboardShortcut({ shortcut: pluginShortcut })
+    expect(registry.getKeyboardShortcuts()).toEqual([
       { id: 'copy', description: 'Copy' },
       pluginShortcut
     ])
   })
 
   test('setProviderSupportedShortcuts with empty array returns no core shortcuts', () => {
-    const state = emptyState()
-    setProviderSupportedShortcuts(state, [])
-    const shortcuts = getKeyboardShortcuts(state)
-    expect(shortcuts).toEqual([])
+    const registry = createKeyboardShortcutRegistry()
+    registry.setProviderSupportedShortcuts([])
+    expect(registry.getKeyboardShortcuts()).toEqual([])
   })
 
   test('getKeyboardShortcuts filters by requiredConfig when appConfig provided', () => {
@@ -91,59 +73,44 @@ describe('keyboardShortcutRegistry', () => {
         { id: 'conditional', description: 'Conditional', requiredConfig: ['featureEnabled'] }
       ]
     }))
-    const module = require('./keyboardShortcutRegistry.js')
-    const state = emptyState()
-    module.setProviderSupportedShortcuts(state, ['always', 'conditional'])
+    const registry = require('./keyboardShortcutRegistry.js').createKeyboardShortcutRegistry()
+    registry.setProviderSupportedShortcuts(['always', 'conditional'])
 
     // Without config, conditional shortcut is excluded
-    expect(module.getKeyboardShortcuts(state)).toEqual([
+    expect(registry.getKeyboardShortcuts()).toEqual([
       { id: 'always', description: 'Always shown' }
     ])
 
     // With config false, conditional shortcut is excluded
-    expect(module.getKeyboardShortcuts(state, { featureEnabled: false })).toEqual([
+    expect(registry.getKeyboardShortcuts({ featureEnabled: false })).toEqual([
       { id: 'always', description: 'Always shown' }
     ])
 
     // With config true, conditional shortcut is included
-    expect(module.getKeyboardShortcuts(state, { featureEnabled: true })).toEqual([
+    expect(registry.getKeyboardShortcuts({ featureEnabled: true })).toEqual([
       { id: 'always', description: 'Always shown' },
       { id: 'conditional', description: 'Conditional', requiredConfig: ['featureEnabled'] }
     ])
   })
 
-  describe('createKeyboardShortcutRegistry', () => {
-    test('registers and lists a plugin shortcut through the factory API', () => {
-      const registry = createKeyboardShortcutRegistry()
-      registry.setProviderSupportedShortcuts(['copy'])
-      const shortcut = { id: 'pluginShortcut', description: 'Plugin Shortcut' }
-      registry.registerKeyboardShortcut({ shortcut })
+  test('two registry instances are fully isolated from each other', () => {
+    // This is the multi-map-on-a-page scenario: a shortcut registered by one map
+    // (e.g. a plugin) must never leak into another map's help panel, and each map's
+    // provider-supported-shortcuts filtering must stay independent.
+    const registryA = createKeyboardShortcutRegistry()
+    const registryB = createKeyboardShortcutRegistry()
 
-      expect(registry.getKeyboardShortcuts()).toEqual([
-        { id: 'copy', description: 'Copy' },
-        shortcut
-      ])
-    })
+    registryA.setProviderSupportedShortcuts(['copy'])
+    registryA.registerKeyboardShortcut({ shortcut: { id: 'onlyOnA', description: 'Only on A' } })
 
-    test('two registry instances are fully isolated from each other', () => {
-      // This is the multi-map-on-a-page scenario: a shortcut registered by one map
-      // (e.g. a plugin) must never leak into another map's help panel, and each map's
-      // provider-supported-shortcuts filtering must stay independent.
-      const registryA = createKeyboardShortcutRegistry()
-      const registryB = createKeyboardShortcutRegistry()
+    registryB.setProviderSupportedShortcuts(['paste'])
 
-      registryA.setProviderSupportedShortcuts(['copy'])
-      registryA.registerKeyboardShortcut({ shortcut: { id: 'onlyOnA', description: 'Only on A' } })
-
-      registryB.setProviderSupportedShortcuts(['paste'])
-
-      expect(registryA.getKeyboardShortcuts()).toEqual([
-        { id: 'copy', description: 'Copy' },
-        { id: 'onlyOnA', description: 'Only on A' }
-      ])
-      expect(registryB.getKeyboardShortcuts()).toEqual([
-        { id: 'paste', description: 'Paste' }
-      ])
-    })
+    expect(registryA.getKeyboardShortcuts()).toEqual([
+      { id: 'copy', description: 'Copy' },
+      { id: 'onlyOnA', description: 'Only on A' }
+    ])
+    expect(registryB.getKeyboardShortcuts()).toEqual([
+      { id: 'paste', description: 'Paste' }
+    ])
   })
 })

--- a/src/App/registry/pluginRegistry.js
+++ b/src/App/registry/pluginRegistry.js
@@ -1,6 +1,5 @@
 // src/core/registry/pluginRegistry.js
 import { registerIcon } from './iconRegistry.js'
-import { registerKeyboardShortcut } from './keyboardShortcutRegistry.js'
 import { allowedSlots } from '../renderer/slots.js'
 import { logger } from '../../services/logger.js'
 
@@ -18,7 +17,7 @@ function validateSlots (item, type) {
   })
 }
 
-export function createPluginRegistry ({ registerButton, registerPanel, registerControl }) {
+export function createPluginRegistry ({ registerButton, registerPanel, registerControl, registerKeyboardShortcut }) {
   const registeredPlugins = []
 
   function registerPlugin (plugin) {

--- a/src/App/registry/pluginRegistry.test.js
+++ b/src/App/registry/pluginRegistry.test.js
@@ -5,7 +5,6 @@ jest.mock('./buttonRegistry.js', () => ({ registerButton: jest.fn() }))
 jest.mock('./panelRegistry.js', () => ({ registerPanel: jest.fn() }))
 jest.mock('./controlRegistry.js', () => ({ registerControl: jest.fn() }))
 jest.mock('./iconRegistry.js', () => ({ registerIcon: jest.fn() }))
-jest.mock('./keyboardShortcutRegistry.js', () => ({ registerKeyboardShortcut: jest.fn() }))
 
 describe('pluginRegistry', () => {
   let pluginRegistry
@@ -18,9 +17,11 @@ describe('pluginRegistry', () => {
     registerPanel = require('./panelRegistry.js').registerPanel
     registerControl = require('./controlRegistry.js').registerControl
     registerIcon = require('./iconRegistry.js').registerIcon
-    registerKeyboardShortcut = require('./keyboardShortcutRegistry.js').registerKeyboardShortcut
+    // registerKeyboardShortcut is injected (per-instance registry), not imported from a module —
+    // see keyboardShortcutRegistry.js's createKeyboardShortcutRegistry.
+    registerKeyboardShortcut = jest.fn()
 
-    pluginRegistry = createPluginRegistry({ registerButton, registerPanel, registerControl })
+    pluginRegistry = createPluginRegistry({ registerButton, registerPanel, registerControl, registerKeyboardShortcut })
   })
 
   it('registers plugin and pushes to registeredPlugins', () => {

--- a/src/App/store/AppProvider.jsx
+++ b/src/App/store/AppProvider.jsx
@@ -10,7 +10,7 @@ import { useMediaQueryDispatch } from '../hooks/useMediaQueryDispatch.js'
 export const AppContext = createContext(null)
 
 export const AppProvider = ({ options, children }) => {
-  const { pluginRegistry, buttonRegistry, panelRegistry, controlRegistry, eventBus, breakpointDetector } = options
+  const { pluginRegistry, buttonRegistry, panelRegistry, controlRegistry, keyboardShortcutRegistry, eventBus, breakpointDetector } = options
 
   const layoutRefs = {
     appContainerRef: useRef(null),
@@ -94,7 +94,8 @@ export const AppProvider = ({ options, children }) => {
     pluginRegistry,
     buttonRegistry,
     panelRegistry,
-    controlRegistry
+    controlRegistry,
+    keyboardShortcutRegistry
   }), [state, dispatch])
 
   return (

--- a/src/InteractiveMap/InteractiveMap.js
+++ b/src/InteractiveMap/InteractiveMap.js
@@ -111,13 +111,16 @@ export default class InteractiveMap {
         history.pushState({ isBack: true }, '', e.currentTarget.getAttribute('href'))
       }
       this.showApp()
+      // App is already mounted, so focus the viewport directly rather than via a mount effect.
+      this.rootEl.querySelector('[role="application"]')?.focus()
     } else if (this._root) {
       // app already open — no-op, no push
     } else {
       if (this.config.manageHistoryState) {
         history.pushState({ isBack: true }, '', e.currentTarget.getAttribute('href'))
       }
-      this.loadApp()
+      // Only a genuine launcher click moves focus into the map — never a resize/breakpoint transition.
+      this.loadApp({ focusOnMount: true })
     }
   }
 
@@ -175,9 +178,11 @@ export default class InteractiveMap {
    * Load and initialize the map application.
    *
    * @internal Not intended for end-user use.
+   * @param {Object} [options]
+   * @param {boolean} [options.focusOnMount=false] - Focus the viewport once mounted; only set by a genuine launcher click.
    * @returns {Promise<void>}
    */
-  async loadApp () {
+  async loadApp ({ focusOnMount = false } = {}) {
     if (this._root || this._isLoading) {
       return
     }
@@ -204,6 +209,7 @@ export default class InteractiveMap {
         id: this.id,
         initialBreakpoint: this._breakpointDetector.getBreakpoint(),
         initialInterfaceType: getInterfaceType(),
+        focusOnMount,
         ...this.config,
         MapProvider,
         mapProviderConfig,

--- a/src/InteractiveMap/InteractiveMap.test.js
+++ b/src/InteractiveMap/InteractiveMap.test.js
@@ -185,6 +185,18 @@ describe('InteractiveMap — loadApp', () => {
     expect(typeof map.someMethod).toBe('function')
     expect(map.eventBus.emit).toHaveBeenCalledWith('app:opened', { statePreserved: false, isFullscreen: false })
   })
+
+  it('defaults focusOnMount to false when not passed', async () => {
+    const map = new InteractiveMap('map', { behaviour: 'buttonFirst', mapProvider: mapProviderMock })
+    await map.loadApp()
+    expect(initialiseApp).toHaveBeenCalledWith(rootEl, expect.objectContaining({ focusOnMount: false }))
+  })
+
+  it('passes focusOnMount through to initialiseApp when set', async () => {
+    const map = new InteractiveMap('map', { behaviour: 'buttonFirst', mapProvider: mapProviderMock })
+    await map.loadApp({ focusOnMount: true })
+    expect(initialiseApp).toHaveBeenCalledWith(rootEl, expect.objectContaining({ focusOnMount: true }))
+  })
 })
 
 // --- _handleButtonClick ---
@@ -193,25 +205,30 @@ describe('InteractiveMap — _handleButtonClick', () => {
   beforeEach(setupBeforeEach)
   afterEach(() => jest.restoreAllMocks())
 
-  it('pushState and loadApp on first open', async () => {
+  it('pushState and loadApp (with focusOnMount) on first open', async () => {
     const map = new InteractiveMap('map', { behaviour: 'buttonFirst', manageHistoryState: true, mapProvider: mapProviderMock })
     jest.spyOn(map, 'loadApp').mockResolvedValue()
     jest.spyOn(history, 'pushState').mockImplementation(() => {})
     await openButtonCallback({ currentTarget: { getAttribute: jest.fn().mockReturnValue('/?mv=map') } })
-    expect(map.loadApp).toHaveBeenCalled()
+    expect(map.loadApp).toHaveBeenCalledWith({ focusOnMount: true })
     expect(history.pushState).toHaveBeenCalledWith({ isBack: true }, '', '/?mv=map')
   })
 
-  it('calls showApp (not loadApp) when map is hidden', async () => {
+  it('calls showApp (not loadApp) and focuses the viewport when map is hidden', async () => {
     const map = new InteractiveMap('map', { behaviour: 'buttonFirst', manageHistoryState: true, mapProvider: mapProviderMock })
     map._isHidden = true
     jest.spyOn(map, 'showApp').mockImplementation(() => {})
     jest.spyOn(map, 'loadApp').mockResolvedValue()
     jest.spyOn(history, 'pushState').mockImplementation(() => {})
+    const viewport = document.createElement('div')
+    viewport.setAttribute('role', 'application')
+    viewport.setAttribute('tabindex', '0')
+    rootEl.appendChild(viewport)
     await openButtonCallback({ currentTarget: { getAttribute: jest.fn().mockReturnValue('/?mv=map') } })
     expect(map.showApp).toHaveBeenCalled()
     expect(map.loadApp).not.toHaveBeenCalled()
     expect(history.pushState).toHaveBeenCalled()
+    expect(viewport).toHaveFocus()
   })
 
   it('skips pushState when manageHistoryState is false', async () => {

--- a/src/config/appConfig.test.js
+++ b/src/config/appConfig.test.js
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import { defaultAppConfig, defaultButtonConfig, scaleFactor } from './appConfig'
 
 jest.mock('../App/store/appContext.js', () => ({
-  useApp: () => ({ listboxIsActive: false })
+  useApp: () => ({ listboxIsActive: false, keyboardShortcutRegistry: { getKeyboardShortcuts: () => [] } })
 }))
 
 describe('defaultAppConfig', () => {

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -23,6 +23,7 @@ const defaults = {
   backAndContinue: null,
   hybridWidth: null, // Defaults to maxMobileWidth if not set
   keyboardHintText: '<span class="im-u-visually-hidden">Press </span><kbd>Shift</kbd> + <span class="im-u-visually-hidden">Question mark</span><kbd aria-hidden="true">?</kbd> <span class="im-u-visually-hidden">to view </span>keyboard shortcuts',
+  mapHintText: 'Press Tab to focus it. Keyboard commands are only available once it has focus.', // Visually hidden text for assitive technology
   mapLabel: 'Interactive map application',
   mapProvider: null,
   mapSize: 'small',
@@ -31,6 +32,7 @@ const defaults = {
   urlPosition: 'sync',
   maxMobileWidth: 640,
   minDesktopWidth: 835,
+  moveControlsHintText: 'A "Move and zoom controls" button is also available, opening further controls for moving and zooming.',
   nudgePanDelta: 5,
   nudgeZoomDelta: 0.1,
   panDelta: 100,

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -32,6 +32,11 @@ export const createMockRegistries = (overrides = {}) => {
       registeredPlugins: [],
       registerPlugin: jest.fn(),
       clear: jest.fn()
+    },
+    keyboardShortcutRegistry: {
+      registerKeyboardShortcut: jest.fn(),
+      setProviderSupportedShortcuts: jest.fn(),
+      getKeyboardShortcuts: jest.fn(() => [])
     }
   }
 }

--- a/src/types.js
+++ b/src/types.js
@@ -730,10 +730,16 @@
  * Optional breakpoint (in pixels) for hybrid behaviour. Defaults to 'maxMobileWidth' when not set.
  *
  * @property {string} [keyboardHintText]
- * HTML string providing keyboard shortcut instructions for accessibility users.
+ * HTML string providing keyboard shortcut instructions for accessibility users, announced via aria-describedby whenever the map viewport gains focus.
+ *
+ * @property {string} [mapHintText]
+ * Visually hidden text, rendered immediately before the map for screen reader users, explaining that it must be focused before keyboard commands work. Prefixed with mapLabel, so multiple maps on one page can be told apart.
  *
  * @property {string} [mapLabel='Interactive map']
- * Accessible label for the map, announced by screen readers.
+ * Accessible label for the map, announced by screen readers. Also prefixed onto mapHintText, so give each map on a page a distinct label.
+ *
+ * @property {string} [moveControlsHintText]
+ * Visually hidden text describing the move controls button, appended to keyboardHintText when enableMoveControls is true.
  *
  * @property {MapProviderDescriptor} [mapProvider]
  * A factory function that returns a map provider instance (e.g. maplibreProvider()).


### PR DESCRIPTION
Adds screen reader hint text per previous DAC audit
Fixes keyboardShortcutsRegistry so its per map instead of module level