### PR TITLE
Refactored button grouping to share some of the new order items logic

### DIFF
--- a/demo/js/draw.js
+++ b/demo/js/draw.js
@@ -131,6 +131,7 @@ const interactiveMap = new InteractiveMap('map', {
   containerHeight: '600px',
   transformRequest: transformVtsRequest3857,
   enableZoomControls: true,
+  enableMoveControls: false,
   readMapText: true,
   // enableFullscreen: true,
   // hasExitButton: true,

--- a/docs/api/button-definition.md
+++ b/docs/api/button-definition.md
@@ -64,22 +64,21 @@ Raw SVG content for the button icon. The outer `<svg>` tag should be excluded.
 ---
 
 ### `group`
-**Type:** `{ name: string, label?: string, order?: number }`
+**Type:** `{ label: string, slotOrder?: number }`
 
-Groups this button with other buttons that share the same `name`. Two or more buttons sharing a group are rendered inside a semantic `<div role="group">` wrapper, collapsing their visual borders into a single grouped unit.
+Groups this button with other buttons that share the same `label` (kebab-cased) — two or more buttons sharing a group are rendered inside a semantic `<div role="group">` wrapper, collapsing their visual borders into a single grouped unit.
 
-- **`name`** — Internal identifier used to collect group members. Buttons with the same `name` are grouped together.
-- **`label`** — Accessible label for the group, announced by screen readers. Defaults to `name` if not provided. Should be a short human-readable description (e.g. `'Zoom controls'`).
-- **`order`** — The group's position within its slot, equivalent to the `order` property on singleton buttons. All buttons in the same group must share the same value. Defaults to `0`.
+- **`label`** — Both the group's identity and its accessible label, announced by screen readers. Buttons whose labels match once kebab-cased (e.g. `'Zoom controls'` and `'zoom-controls'`) share a group. Should be a short human-readable description.
+- **`slotOrder`** — The group's position within its slot, equivalent to the `order` property on singleton buttons. Defaults to `0`. If buttons in the same group declare different values, a dev-mode warning is logged and the first one encountered is used.
 
 ```js
 // Two buttons rendered as a labelled group at slot position 2
-{ group: { name: 'zoom', label: 'Zoom controls', order: 2 }, ... }
+{ group: { label: 'Zoom controls', slotOrder: 2 }, ... }
 ```
 
 The `order` property on each button's breakpoint config (e.g. `desktop.order`) controls the button's position *within* the group when an explicit sequence is needed. If omitted, buttons appear in their declaration order.
 
-> If only one button declares a given group name, it is rendered as a standalone button and the group wrapper is not created.
+> If only one button declares a given group label, it is rendered as a standalone button — no group wrapper — but still at the group's own `slotOrder`.
 
 ---
 
@@ -272,7 +271,7 @@ The [slot](./slots.md) where the button should appear at this breakpoint. Slots 
 
 For **ungrouped buttons**, this is the button's position within its slot.
 
-For **grouped buttons**, this is the button's position *within its group*. The group's position within the slot is controlled by `group.order` instead. If omitted, buttons appear in their declaration order within the group.
+For **grouped buttons**, this is the button's position *within its group*. The group's position within the slot is controlled by `group.slotOrder` instead. If omitted, buttons appear in their declaration order within the group.
 
 ---
 

--- a/docs/api/slots.md
+++ b/docs/api/slots.md
@@ -86,7 +86,7 @@ Multiple elements can share the same slot. Panels and controls render in the ord
 > [!NOTE]
 > Order values are clamped to the valid range. If you specify an order larger than the number of buttons in the slot, the button is placed last.
 
-When buttons belong to a group, `order` controls position within the group. The group itself is positioned in the slot using `group.order`.
+When buttons belong to a group, `order` controls position within the group. The group itself is positioned in the slot using `group.slotOrder`.
 
 ## Button-Adjacent Panels
 

--- a/plugins/beta/use-location/src/manifest.js
+++ b/plugins/beta/use-location/src/manifest.js
@@ -18,7 +18,7 @@ export const manifest = {
 
   buttons: [{
     id: 'useLocation',
-    group: { name: 'location', label: 'Location', order: 0 },
+    group: { label: 'Location', slotOrder: 0 },
     label: 'Use your location',
     iconId: 'locateFixed',
     keepFocus: true,

--- a/src/App/renderer/groupByKey.js
+++ b/src/App/renderer/groupByKey.js
@@ -1,0 +1,28 @@
+import { stringToKebab } from '../../utils/stringToKebab.js'
+
+/**
+ * Partitions a list of items into buckets, keyed by `keyFn(item)` kebab-cased — two items
+ * share a bucket by producing the same key (so 'Map Size' and 'map size' merge). Items for
+ * which `keyFn` returns a falsy value all share one `null`-keyed bucket. Bucket iteration
+ * order follows first-encountered order, same as `Map`.
+ *
+ * Shared by `groupIntoTabs` (panel/control tabs) and `mapButtons` (button groups) — the two
+ * callers differ only in what happens *after* bucketing (how a bucket's own order/label is
+ * derived), not in how items get partitioned.
+ *
+ * @returns {Map<string|null, object[]>}
+ */
+export function groupByKey ({ items, keyFn }) {
+  const buckets = new Map()
+
+  for (const item of items) {
+    const raw = keyFn(item)
+    const key = raw ? stringToKebab(raw) : null
+    if (!buckets.has(key)) {
+      buckets.set(key, [])
+    }
+    buckets.get(key).push(item)
+  }
+
+  return buckets
+}

--- a/src/App/renderer/groupByKey.test.js
+++ b/src/App/renderer/groupByKey.test.js
@@ -1,0 +1,39 @@
+import { groupByKey } from './groupByKey.js'
+
+describe('groupByKey', () => {
+  it('returns one bucket per distinct key', () => {
+    const items = [{ id: 'a', k: 'Styles' }, { id: 'b', k: 'Sizes' }]
+    const buckets = groupByKey({ items, keyFn: item => item.k })
+    expect([...buckets.keys()].sort()).toEqual(['sizes', 'styles'])
+  })
+
+  it('lowercases the key, hyphenating only camelCase-style boundaries (stringToKebab)', () => {
+    const items = [{ id: 'a', k: 'mapSize' }]
+    const buckets = groupByKey({ items, keyFn: item => item.k })
+    expect([...buckets.keys()]).toEqual(['map-size'])
+  })
+
+  it('merges items whose key differs only by case/whitespace into one bucket', () => {
+    const items = [{ id: 'a', k: 'Map Size' }, { id: 'b', k: 'map size' }]
+    const buckets = groupByKey({ items, keyFn: item => item.k })
+    expect(buckets.size).toBe(1)
+    expect([...buckets.values()][0]).toHaveLength(2)
+  })
+
+  it('puts items with no key into one null-keyed bucket', () => {
+    const items = [{ id: 'a' }, { id: 'b' }]
+    const buckets = groupByKey({ items, keyFn: () => null })
+    expect(buckets.size).toBe(1)
+    expect(buckets.get(null)).toHaveLength(2)
+  })
+
+  it('keeps items within a bucket in their original relative order', () => {
+    const items = [{ id: 'a', k: 'g' }, { id: 'b', k: 'g' }, { id: 'c', k: 'g' }]
+    const buckets = groupByKey({ items, keyFn: item => item.k })
+    expect(buckets.get('g').map(i => i.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  it('returns an empty map for an empty list', () => {
+    expect(groupByKey({ items: [], keyFn: () => 'x' }).size).toBe(0)
+  })
+})

--- a/src/App/renderer/groupIntoTabs.js
+++ b/src/App/renderer/groupIntoTabs.js
@@ -1,11 +1,11 @@
 import { orderItems } from './orderItems.js'
-import { stringToKebab } from '../../utils/stringToKebab.js'
+import { groupByKey } from './groupByKey.js'
 
 /**
  * Groups a flat list of `{ id, order, tab, element }` items into tabs, when warranted.
  *
- * Items are partitioned by `tab`, kebab-cased as the join key — two items share a tab by
- * producing the same key. Items with no `tab` share one fallback bucket. Returns `null` when
+ * Items are partitioned by `tab` via `groupByKey` — two items share a tab by producing the
+ * same kebab-cased key. Items with no `tab` share one fallback bucket. Returns `null` when
  * there's one bucket or fewer, so the caller can fall back to flat rendering unchanged.
  *
  * Each bucket's members are ordered via `orderItems`; the resulting tab's own `order` and
@@ -13,17 +13,15 @@ import { stringToKebab } from '../../utils/stringToKebab.js'
  * item that "wins" the position also wins the label, so there's nothing separate to reconcile
  * when members disagree. The tabs themselves are then ordered the same way, via `orderItems`
  * again — no new ordering concept, just the existing one applied twice.
+ *
+ * This derived-order approach is safe here because tabs are mutually exclusive — only the
+ * active tab's content is ever visible, so a "losing" member's own order never has to compete
+ * against anything outside its own tab at the same time. `mapButtons`'s button groups don't
+ * have that property (every group renders simultaneously), so they don't derive a group's
+ * order from its members the same way — see `mapButtons.js`.
  */
 export function groupIntoTabs ({ items, fallbackLabel }) {
-  const buckets = new Map() // kebab key (or null for the untagged/fallback bucket) -> members[]
-
-  for (const item of items) {
-    const key = item.tab ? stringToKebab(item.tab) : null
-    if (!buckets.has(key)) {
-      buckets.set(key, [])
-    }
-    buckets.get(key).push(item)
-  }
+  const buckets = groupByKey({ items, keyFn: item => item.tab })
 
   if (buckets.size <= 1) {
     return null

--- a/src/App/renderer/mapButtons.js
+++ b/src/App/renderer/mapButtons.js
@@ -1,6 +1,8 @@
 // src/core/renderers/mapButtons.js
 import { MapButton } from '../components/MapButton/MapButton.jsx'
 import { allowedSlots } from './slots.js'
+import { groupByKey } from './groupByKey.js'
+import { orderItems } from './orderItems.js'
 import { logger } from '../../services/logger.js'
 
 function getMatchingButtons ({ appState, buttonConfig, slot, evaluateProp }) {
@@ -74,47 +76,6 @@ function createButtonClickHandler (config, appState, evaluateProp) {
   }
 }
 
-/**
- * Resolves the group name from a button config's group property.
- * Accepts either the new object form `{ name, label?, order? }` or a deprecated plain string.
- * @param {string|{name: string, label?: string, order?: number}|null|undefined} group
- * @returns {string|null}
- */
-function resolveGroupName (group) {
-  if (group == null) {
-    return null
-  }
-  return typeof group === 'string' ? group : (group.name ?? null)
-}
-
-/**
- * Resolves the accessible label for a group.
- * Uses `label` if provided, otherwise falls back to `name`.
- * @param {string|{name: string, label?: string, order?: number}|null|undefined} group
- * @returns {string}
- */
-function resolveGroupLabel (group) {
-  if (!group) {
-    return ''
-  }
-  if (typeof group === 'string') {
-    return group
-  }
-  return group.label ?? group.name ?? ''
-}
-
-/**
- * Resolves the slot-level order for a group.
- * @param {string|{name: string, label?: string, order?: number}|null|undefined} group
- * @returns {number}
- */
-function resolveGroupOrder (group) {
-  if (!group || typeof group === 'string') {
-    return 0
-  }
-  return group.order ?? 0
-}
-
 function applySlotExclusivity (matching, appState) {
   let exclusivePluginId = null
 
@@ -181,6 +142,69 @@ function SlotButton ({ buttonId, config, appState, appConfig, evaluateProp }) {
   )
 }
 
+/**
+ * Ungrouped buttons — one result item per button, ordered by its own breakpoint-level
+ * slot position.
+ */
+function buildUngroupedItems (members, ctx) {
+  return members.map(([buttonId, config]) => ({
+    id: buttonId,
+    type: 'button',
+    order: config[ctx.breakpoint]?.order ?? 0,
+    element: <SlotButton key={buttonId} {...slotButtonProps({ buttonId, config, ...ctx })} />
+  }))
+}
+
+/**
+ * A named group's own slot order/label come from whichever member is encountered first —
+ * unlike panel tabs (see groupIntoTabs.js), this is never derived from members' own order:
+ * groups render simultaneously (not one-at-a-time like tabs), so an unspecified order
+ * defaults to 0, same as every other slot item, rather than borrowing a member's position.
+ * A single-member group still degrades to a plain button (no wrapping container), but keeps
+ * the group's own slot order rather than falling back to its own breakpoint-level order.
+ */
+function buildGroupItem (key, members, ctx) {
+  const [, firstConfig] = members[0]
+  const order = firstConfig.group.slotOrder ?? 0
+
+  /* istanbul ignore next */
+  if (process.env.NODE_ENV !== 'production') {
+    const distinctOrders = new Set(members.map(([, config]) => config.group?.slotOrder ?? 0))
+    if (distinctOrders.size > 1) {
+      logger.warn(`Button group "${firstConfig.group.label}" has inconsistent slotOrder values (${[...distinctOrders].join(', ')}) across its members — using ${order} (the first member's).`)
+    }
+  }
+
+  if (members.length < 2) {
+    const [buttonId, config] = members[0]
+    return {
+      id: buttonId,
+      type: 'button',
+      order,
+      element: <SlotButton key={buttonId} {...slotButtonProps({ buttonId, config, ...ctx })} />
+    }
+  }
+
+  // Order members within the group the same way panel/control content orders within a tab
+  const sorted = orderItems(members.map(([buttonId, config]) => ({
+    id: buttonId,
+    order: config[ctx.breakpoint]?.order ?? 0,
+    buttonId,
+    config
+  })))
+
+  return {
+    id: `group-${key}`,
+    type: 'group',
+    order,
+    element: (
+      <div key={`group-${key}`} role='group' aria-label={firstConfig.group.label} className='im-c-button-group'>{/* NOSONAR - div with role="group" is correct for a button group */}
+        {sorted.map(({ buttonId, config }) => <SlotButton key={buttonId} {...slotButtonProps({ buttonId, config, ...ctx })} />)}
+      </div>
+    )
+  }
+}
+
 function mapButtons ({ slot, appState, appConfig, evaluateProp }) {
   const { buttonConfig, breakpoint } = appState
 
@@ -191,86 +215,17 @@ function mapButtons ({ slot, appState, appConfig, evaluateProp }) {
     return []
   }
 
-  // Partition matching buttons into named groups and ungrouped singletons
-  const groupMap = new Map() // name -> { label, order, members: [[buttonId, config]] }
-  const singletons = []
-
-  matching.forEach(([buttonId, config]) => {
-    const { group } = config
-
-    if (group == null) {
-      singletons.push([buttonId, config])
-      return
-    }
-
-    /* istanbul ignore next */
-    if (process.env.NODE_ENV !== 'production' && typeof group === 'string') {
-      logger.warn(`Button "${buttonId}": group should be an object { name, label?, order? } — string groups are deprecated.`)
-    }
-
-    const name = resolveGroupName(group)
-    const label = resolveGroupLabel(group)
-    const order = resolveGroupOrder(group)
-
-    if (groupMap.has(name)) {
-      const existing = groupMap.get(name)
-      /* istanbul ignore next */
-      if (process.env.NODE_ENV !== 'production' && existing.order !== order) {
-        logger.warn(`Group "${name}" has inconsistent order values (${existing.order} vs ${order}). Using the lower value.`)
-        existing.order = Math.min(existing.order, order)
-      }
-    } else {
-      groupMap.set(name, { label, order, members: [] })
-    }
-
-    groupMap.get(name).members.push([buttonId, config])
-  })
+  // Partition into named groups (keyed by kebab-cased group.label) plus one ungrouped bucket
+  const buckets = groupByKey({ items: matching, keyFn: ([, config]) => config.group?.label })
+  const ctx = { breakpoint, appState, appConfig, evaluateProp }
 
   const result = []
-
-  // Ungrouped buttons — order is the breakpoint-level slot position
-  for (const btn of singletons) {
-    const [buttonId, config] = btn
-    const order = config[breakpoint]?.order ?? 0
-    result.push({
-      id: buttonId,
-      type: 'button',
-      order,
-      element: <SlotButton key={buttonId} {...slotButtonProps({ buttonId, config, appState, appConfig, evaluateProp })} />
-    })
-  }
-
-  for (const [groupName, { label, order: groupOrder, members }] of groupMap) {
-    if (members.length < 2) {
-      // Singleton group: degrade to a regular button using the group's slot order
-      const [buttonId, config] = members[0]
-      const order = groupOrder || config[breakpoint]?.order || 0
-      result.push({
-        id: buttonId,
-        type: 'button',
-        order,
-        element: <SlotButton key={buttonId} {...slotButtonProps({ buttonId, config, appState, appConfig, evaluateProp })} />
-      })
-      continue
+  for (const [key, members] of buckets) {
+    if (key === null) {
+      result.push(...buildUngroupedItems(members, ctx))
+    } else {
+      result.push(buildGroupItem(key, members, ctx))
     }
-
-    // Sort group members by their intra-group order (breakpoint-level order prop)
-    const sorted = [...members].sort((a, b) => {
-      const orderA = a[1][breakpoint]?.order ?? 0
-      const orderB = b[1][breakpoint]?.order ?? 0
-      return orderA - orderB
-    })
-
-    result.push({
-      id: `group-${groupName}`,
-      type: 'group',
-      order: groupOrder,
-      element: (
-        <div key={`group-${groupName}`} role='group' aria-label={label} className='im-c-button-group'>{/* NOSONAR - div with role="group" is correct for a button group */}
-          {sorted.map(([buttonId, config]) => <SlotButton key={buttonId} {...slotButtonProps({ buttonId, config, appState, appConfig, evaluateProp })} />)}
-        </div>
-      )
-    })
   }
 
   return result
@@ -280,8 +235,5 @@ export {
   mapButtons,
   getMatchingButtons,
   applySlotExclusivity,
-  SlotButton,
-  resolveGroupName,
-  resolveGroupLabel,
-  resolveGroupOrder
+  SlotButton
 }

--- a/src/App/renderer/mapButtons.test.js
+++ b/src/App/renderer/mapButtons.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { mapButtons, getMatchingButtons, applySlotExclusivity, SlotButton, resolveGroupName, resolveGroupLabel, resolveGroupOrder } from './mapButtons.js'
+import { mapButtons, getMatchingButtons, applySlotExclusivity, SlotButton } from './mapButtons.js'
 import { logger } from '../../services/logger.js'
 import { getPanelConfig } from '../registry/panelRegistry.js'
 
@@ -45,52 +45,6 @@ describe('mapButtons module', () => {
     }
     appState.buttonConfig = ({})
     getPanelConfig.mockReturnValue({})
-  })
-
-  // -------------------------
-  // resolveGroup* helper tests
-  // -------------------------
-  describe('resolveGroupName', () => {
-    it('returns null when group is null or undefined', () => {
-      expect(resolveGroupName(null)).toBeNull()
-      expect(resolveGroupName(undefined)).toBeNull()
-    })
-    it('returns the string when group is a string', () => {
-      expect(resolveGroupName('g1')).toBe('g1')
-    })
-    it('returns group.name when group is an object', () => {
-      expect(resolveGroupName({ name: 'g1' })).toBe('g1')
-      expect(resolveGroupName({ name: undefined })).toBeNull()
-    })
-  })
-
-  describe('resolveGroupLabel', () => {
-    it('returns empty string when group is falsy', () => {
-      expect(resolveGroupLabel(null)).toBe('')
-      expect(resolveGroupLabel(undefined)).toBe('')
-    })
-    it('returns the string itself when group is a string', () => {
-      expect(resolveGroupLabel('My Group')).toBe('My Group')
-    })
-    it('returns group.label when provided, else group.name, else empty string', () => {
-      expect(resolveGroupLabel({ name: 'g1', label: 'Group One' })).toBe('Group One')
-      expect(resolveGroupLabel({ name: 'g1' })).toBe('g1')
-      expect(resolveGroupLabel({ order: 5 })).toBe('')
-    })
-  })
-
-  describe('resolveGroupOrder', () => {
-    it('returns 0 when group is falsy', () => {
-      expect(resolveGroupOrder(null)).toBe(0)
-      expect(resolveGroupOrder(undefined)).toBe(0)
-    })
-    it('returns 0 when group is a string', () => {
-      expect(resolveGroupOrder('g1')).toBe(0)
-    })
-    it('returns group.order when provided, else 0', () => {
-      expect(resolveGroupOrder({ name: 'g1', order: 5 })).toBe(5)
-      expect(resolveGroupOrder({ name: 'g1' })).toBe(0)
-    })
   })
 
   // -------------------------
@@ -283,68 +237,85 @@ describe('mapButtons module', () => {
       expect(result[0]).toMatchObject({ id: 'b1', type: 'button', order: 1 })
     })
 
-    it('renders grouped buttons as a single group item with role=group', () => {
+    it('renders grouped buttons as a single group item with role=group, keyed by kebab-cased label', () => {
       appState.buttonConfig = ({
-        b1: { ...baseBtn, group: { name: 'g1', label: 'Group 1', order: 2 } },
-        b2: { ...baseBtn, desktop: { slot: 'header', order: 2 }, group: { name: 'g1', label: 'Group 1', order: 2 } }
+        b1: { ...baseBtn, group: { label: 'Group 1', slotOrder: 2 } },
+        b2: { ...baseBtn, desktop: { slot: 'header', order: 2 }, group: { label: 'Group 1', slotOrder: 2 } }
       })
       const result = map()
       expect(result).toHaveLength(1)
-      expect(result[0]).toMatchObject({ id: 'group-g1', type: 'group', order: 2 })
+      // stringToKebab only hyphenates camelCase boundaries, not spaces — this id is an internal
+      // React key/identifier only, never rendered as a literal DOM id, so that's harmless here.
+      expect(result[0]).toMatchObject({ id: 'group-group 1', type: 'group', order: 2 })
       expect(result[0].element.props.role).toBe('group')
       expect(result[0].element.props['aria-label']).toBe('Group 1')
     })
 
-    it('uses group name as aria-label when no explicit label is provided', () => {
+    it('merges group labels that differ only by case/whitespace into one group', () => {
       appState.buttonConfig = ({
-        b1: { ...baseBtn, group: { name: 'g1', order: 0 } },
-        b2: { ...baseBtn, group: { name: 'g1', order: 0 } }
-      })
-      const result = map()
-      expect(result[0].element.props['aria-label']).toBe('g1')
-    })
-
-    it('sorts group members by intra-group order', () => {
-      appState.buttonConfig = ({
-        b1: { ...baseBtn, group: { name: 'g1', order: 0 }, desktop: { slot: 'header', order: 3 } },
-        b2: { ...baseBtn, group: { name: 'g1', order: 0 }, desktop: { slot: 'header', order: 1 } },
-        b3: { ...baseBtn, group: { name: 'g1', order: 0 }, desktop: { slot: 'header', order: 2 } }
+        b1: { ...baseBtn, group: { label: 'Zoom Controls' } },
+        b2: { ...baseBtn, group: { label: 'zoom controls' } }
       })
       const result = map()
       expect(result).toHaveLength(1)
-      const children = result[0].element.props.children
-      expect(children[0].props.buttonId).toBe('b2')
-      expect(children[1].props.buttonId).toBe('b3')
-      expect(children[2].props.buttonId).toBe('b1')
+      // First-encountered member's raw label wins, same convention as panel tabs (groupIntoTabs.js)
+      expect(result[0].element.props['aria-label']).toBe('Zoom Controls')
     })
 
-    it('renders singleton groups as regular buttons using group slot order', () => {
-      appState.buttonConfig = ({ b1: { ...baseBtn, group: { name: 'g1', label: 'Group 1', order: 3 } } })
+    it('orders group members via orderItems — unordered members keep natural sequence, an ordered one splices in by position', () => {
+      appState.buttonConfig = ({
+        b1: { ...baseBtn, group: { label: 'g1' }, desktop: { slot: 'header' } },
+        b2: { ...baseBtn, group: { label: 'g1' }, desktop: { slot: 'header', order: 1 } },
+        b3: { ...baseBtn, group: { label: 'g1' }, desktop: { slot: 'header' } }
+      })
+      const children = map()[0].element.props.children
+      expect(children.map(c => c.props.buttonId)).toEqual(['b2', 'b1', 'b3'])
+    })
+
+    it('renders singleton groups as regular buttons using the group\'s slot order', () => {
+      appState.buttonConfig = ({ b1: { ...baseBtn, group: { label: 'Group 1', slotOrder: 3 } } })
       const result = map()
       expect(result).toHaveLength(1)
       expect(result[0]).toMatchObject({ id: 'b1', type: 'button', order: 3 })
     })
 
-    it('falls back to breakpoint order for singleton group when group order is 0', () => {
-      appState.buttonConfig = ({ b1: { ...baseBtn, desktop: { slot: 'header', order: 4 }, group: { name: 'g1', order: 0 } } })
-      expect(map()[0].order).toBe(4)
-    })
-
-    it('falls back to 0 for singleton group when both group order and breakpoint order are absent', () => {
-      appState.buttonConfig = ({ b1: { ...baseBtn, desktop: { slot: 'header' }, group: { name: 'g1', order: 0 } } })
+    it('does not fall back to the button\'s own breakpoint order when group slotOrder is explicitly 0', () => {
+      appState.buttonConfig = ({ b1: { ...baseBtn, desktop: { slot: 'header', order: 4 }, group: { label: 'g1', slotOrder: 0 } } })
       expect(map()[0].order).toBe(0)
     })
 
-    it('sorts group members treating missing breakpoint order as 0', () => {
+    it('falls back to 0 for singleton group when group slotOrder is absent', () => {
+      appState.buttonConfig = ({ b1: { ...baseBtn, desktop: { slot: 'header' }, group: { label: 'g1' } } })
+      expect(map()[0].order).toBe(0)
+    })
+
+    it('warns in dev mode when group members declare inconsistent slotOrder values, using the first one encountered', () => {
       appState.buttonConfig = ({
-        b1: { ...baseBtn, group: { name: 'g1', order: 0 }, desktop: { slot: 'header', order: 2 } },
-        b2: { ...baseBtn, group: { name: 'g1', order: 0 }, desktop: { slot: 'header' } },
-        b3: { ...baseBtn, group: { name: 'g1', order: 0 }, desktop: { slot: 'header', order: 1 } }
+        b1: { ...baseBtn, group: { label: 'g1', slotOrder: 2 } },
+        b2: { ...baseBtn, desktop: { slot: 'header', order: 1 }, group: { label: 'g1', slotOrder: 5 } }
       })
-      const children = map()[0].element.props.children
-      expect(children[0].props.buttonId).toBe('b2')
-      expect(children[1].props.buttonId).toBe('b3')
-      expect(children[2].props.buttonId).toBe('b1')
+      const result = map()
+      expect(result[0].order).toBe(2)
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('inconsistent slotOrder values'))
+    })
+
+    it('does not warn when group members agree on slotOrder', () => {
+      appState.buttonConfig = ({
+        b1: { ...baseBtn, group: { label: 'g1', slotOrder: 2 } },
+        b2: { ...baseBtn, desktop: { slot: 'header', order: 1 }, group: { label: 'g1', slotOrder: 2 } }
+      })
+      map()
+      expect(logger.warn).not.toHaveBeenCalled()
+    })
+
+    it('mixes grouped and ungrouped buttons in the same slot', () => {
+      appState.buttonConfig = ({
+        solo: { ...baseBtn, desktop: { slot: 'header', order: 1 } },
+        b1: { ...baseBtn, group: { label: 'g1' }, desktop: { slot: 'header' } },
+        b2: { ...baseBtn, group: { label: 'g1' }, desktop: { slot: 'header' } }
+      })
+      const result = map()
+      expect(result.map(r => r.id).sort()).toEqual(['group-g1', 'solo'])
     })
 
     it('falls back to order 0 when order is not specified in breakpoint config', () => {

--- a/src/config/appConfig.js
+++ b/src/config/appConfig.js
@@ -74,7 +74,7 @@ export const defaultAppConfig = {
     desktop: buttonSlots
   }, {
     id: 'zoomIn',
-    group: { name: 'zoom', label: 'Zoom controls', order: 0 },
+    group: { label: 'Zoom controls', slotOrder: 0 },
     label: 'Zoom in',
     iconId: 'plus',
     keepFocus: true,
@@ -86,7 +86,7 @@ export const defaultAppConfig = {
     desktop: buttonSlots
   }, {
     id: 'zoomOut',
-    group: { name: 'zoom', label: 'Zoom controls', order: 0 },
+    group: { label: 'Zoom controls', slotOrder: 0 },
     label: 'Zoom out',
     iconId: 'minus',
     keepFocus: true,

--- a/src/types.js
+++ b/src/types.js
@@ -170,8 +170,12 @@
  * @property {(context: PluginContext) => boolean} [excludeWhen]
  * Callback to determine if the button should be excluded from rendering.
  *
- * @property {string} [group]
- * Button group label for grouping related buttons.
+ * @property {{ label: string, slotOrder?: number }} [group]
+ * Groups this button with any other button sharing the same `label` (kebab-cased) into one
+ * `role="group"` container, rendered as a single item in the slot. `label` is also the
+ * group's accessible name (aria-label) — buttons whose labels differ only by case/whitespace
+ * still merge into one group. `slotOrder` positions the group itself within the slot (defaults
+ * to 0); each button's own breakpoint `order` controls its position *within* the group.
  *
  * @property {(context: PluginContext) => boolean} [hiddenWhen]
  * Callback to determine if the button should be hidden. Sets display: none if true.


### PR DESCRIPTION
The new panel slots and tab slots work created some ordering utilities for re use. These piece of work reworks the button grouping to follow a similar pattern and reuse som of the ordering logic. It also drops the name prop and uses a kebab cased label as is the current pattern. No breaking change though as the label was already required