### PR TITLE
Isolate experimental release tags from the shared pre-release npm tag

### DIFF
--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -53,6 +53,14 @@ validate_version_bump() {
 }
 
 determine_release_tag() {
+  if [[ "$TAG_NAME" =~ -([a-zA-Z0-9-]+)\. ]]; then
+    local label="${BASH_REMATCH[1]}"
+    if [[ "$label" != "alpha" && "$label" != "beta" ]]; then
+      echo "$label"
+      return
+    fi
+  fi
+
   if [[ "$IS_PRE_RELEASE" == "true" ]] || [[ "$TAG_NAME" =~ $PRE_RELEASE_PATTERN ]]; then
     echo "pre-release"
   else


### PR DESCRIPTION
The fix: stops every non-alpha/beta prerelease tag from being dumped into the same shared pre-release npm tag, so one-off experimental builds get their own dist-tag instead of overwriting the real alpha channel.

For v1 and beyond: unaffected — a genuine final release tag like v1.0.0 has no -suffix at all, so it skips both the new label check and the old prerelease check and falls straight through to latest, exactly as today; and a real v1.1.0-beta.1 still correctly lands on pre-release. The new branch only ever fires for a custom label like -fmp.1 that isn't alpha or beta.