### PR TITLE
services.getPlugin added for calling another plugins methods within a plugin

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -168,3 +168,27 @@ eventBus.emit('my-plugin:custom-event', { data: 'value' })
 ```
 
 See [Events](../api.md#events) for available event name constants.
+
+---
+
+#### `getPlugin`
+
+Looks up another registered plugin by id and returns its instance — the same
+object its factory returned (e.g. what `createDrawPlugin()` gave the host
+app), so you can call its API methods directly.
+
+```js
+const drawPlugin = context.services.getPlugin('draw')
+drawPlugin?.newPolygon('boundary', { onGeometryChange: () => true })
+```
+
+Returns `undefined` if no plugin with that id is registered — a host app is
+always free to omit an optional dependency, so treat the result as possibly
+absent rather than erroring.
+
+> [!NOTE]
+> Finding a plugin isn't the same as it being safe to call — its methods bind
+> once that plugin has mounted, and some need further setup after that. Hold
+> onto the reference early if you like, but gate the actual call on that
+> plugin's own readiness convention where one exists, e.g. `draw:ready` on
+> `eventBus` before calling anything on `getPlugin('draw')`.

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -19,7 +19,7 @@ export const App = (props) => {
   return (
     <AppProvider options={props}>
       <MapProvider options={props}>
-        <ServiceProvider eventBus={props.eventBus}>
+        <ServiceProvider eventBus={props.eventBus} pluginRegistry={props.pluginRegistry}>
           <PluginProvider>
             <PluginInits />
             <Layout />

--- a/src/App/App.test.jsx
+++ b/src/App/App.test.jsx
@@ -70,7 +70,8 @@ describe('App', () => {
   })
 
   test('renders component hierarchy with props', () => {
-    const props = { mapProvider: 'test', extraProp: 'value', eventBus: mockEventBus }
+    const mockPluginRegistry = { getPlugin: jest.fn() }
+    const props = { mapProvider: 'test', extraProp: 'value', eventBus: mockEventBus, pluginRegistry: mockPluginRegistry }
 
     render(<App {...props} />)
 
@@ -98,6 +99,10 @@ describe('App', () => {
     // Verify eventBus exists
     expect(appProviderProps.options.eventBus).toBe(mockEventBus)
     expect(mapProviderProps.options.eventBus).toBe(mockEventBus)
+
+    // Verify pluginRegistry reaches ServiceProvider
+    const serviceProviderProps = ServiceProvider.mock.calls[0][0]
+    expect(serviceProviderProps.pluginRegistry).toBe(mockPluginRegistry)
   })
 
   test('calls removeLoadingState and emits APP_READY on mount', () => {

--- a/src/App/registry/pluginRegistry.js
+++ b/src/App/registry/pluginRegistry.js
@@ -73,9 +73,22 @@ export function createPluginRegistry ({ registerButton, registerPanel, registerC
     registeredPlugins.length = 0
   }
 
+  /**
+   * Look up another registered plugin's instance by id. Returns `undefined`
+   * if not registered; found doesn't mean ready to call — see services.getPlugin
+   * in docs/api/context.md.
+   *
+   * @param {string} id - Plugin id, e.g. `'draw'`.
+   * @returns {object|undefined}
+   */
+  function getPlugin (id) {
+    return registeredPlugins.find(plugin => plugin.id === id)?._originalPlugin
+  }
+
   return {
     registeredPlugins,
     registerPlugin,
+    getPlugin,
     clear
   }
 }

--- a/src/App/registry/pluginRegistry.test.js
+++ b/src/App/registry/pluginRegistry.test.js
@@ -185,6 +185,21 @@ describe('pluginRegistry', () => {
     })
   })
 
+  describe('getPlugin', () => {
+    it('returns the _originalPlugin reference for a registered plugin id', () => {
+      const originalPlugin = { newPolygon: jest.fn() }
+      const plugin = { id: 'draw', config: {}, manifest: {}, _originalPlugin: originalPlugin }
+
+      pluginRegistry.registerPlugin(plugin)
+
+      expect(pluginRegistry.getPlugin('draw')).toBe(originalPlugin)
+    })
+
+    it('returns undefined for an id that is not registered', () => {
+      expect(pluginRegistry.getPlugin('does-not-exist')).toBeUndefined()
+    })
+  })
+
   it('clears all registered plugins', () => {
     const pluginA = { id: 'A', config: {}, manifest: {} }
     const pluginB = { id: 'B', config: {}, manifest: {} }

--- a/src/App/store/ServiceProvider.jsx
+++ b/src/App/store/ServiceProvider.jsx
@@ -10,7 +10,7 @@ import { patternRegistry } from '../../services/patternRegistry.js'
 
 export const ServiceContext = createContext(null)
 
-export const ServiceProvider = ({ eventBus, children }) => {
+export const ServiceProvider = ({ eventBus, pluginRegistry, children }) => {
   const { id, handleExitClick, symbolDefaults: constructorSymbolDefaults } = useConfig()
   const mapStatusRef = useRef(null)
   const announce = useMemo(() => createAnnouncer(mapStatusRef), [])
@@ -26,8 +26,10 @@ export const ServiceProvider = ({ eventBus, children }) => {
     mapStatusRef,
     closeApp: () => closeApp(id, handleExitClick, eventBus),
     symbolRegistry,
-    patternRegistry
-  }), [announce, hints])
+    patternRegistry,
+    // See pluginRegistry.js's getPlugin() for what this does and doesn't guarantee.
+    getPlugin: (pluginId) => pluginRegistry?.getPlugin(pluginId)
+  }), [announce, hints, pluginRegistry])
 
   return (
     <ServiceContext.Provider value={services}>

--- a/src/App/store/ServiceProvider.test.jsx
+++ b/src/App/store/ServiceProvider.test.jsx
@@ -34,7 +34,10 @@ jest.mock('../store/configContext.js', () => ({
 
 describe('ServiceProvider', () => {
   const mockEventBus = { on: jest.fn(), off: jest.fn(), emit: jest.fn() }
-  const wrapper = ({ children }) => <ServiceProvider eventBus={mockEventBus}>{children}</ServiceProvider>
+  const mockPluginRegistry = { getPlugin: jest.fn(() => ({ newPolygon: jest.fn() })) }
+  const wrapper = ({ children }) => (
+    <ServiceProvider eventBus={mockEventBus} pluginRegistry={mockPluginRegistry}>{children}</ServiceProvider>
+  )
 
   test('provides announce, reverseGeocode, eventBus, and closeApp via context', () => {
     const { result } = renderHook(() => React.useContext(ServiceContext), { wrapper })
@@ -66,6 +69,22 @@ describe('ServiceProvider', () => {
     const { result } = renderHook(() => React.useContext(ServiceContext), { wrapper })
     result.current.hints.show('<b>test</b>', { duration: 2000 })
     expect(mockShow).toHaveBeenCalledWith('<b>test</b>', { duration: 2000 })
+  })
+
+  test('getPlugin delegates to pluginRegistry.getPlugin', () => {
+    const { result } = renderHook(() => React.useContext(ServiceContext), { wrapper })
+
+    const plugin = result.current.getPlugin('draw')
+
+    expect(mockPluginRegistry.getPlugin).toHaveBeenCalledWith('draw')
+    expect(plugin).toEqual({ newPolygon: expect.any(Function) })
+  })
+
+  test('getPlugin returns undefined when no pluginRegistry is provided', () => {
+    const noRegistryWrapper = ({ children }) => <ServiceProvider eventBus={mockEventBus}>{children}</ServiceProvider>
+    const { result } = renderHook(() => React.useContext(ServiceContext), { wrapper: noRegistryWrapper })
+
+    expect(result.current.getPlugin('draw')).toBeUndefined()
   })
 
   test('closeApp calls closeApp service with id and handleExitClick', () => {


### PR DESCRIPTION
services.getPlugin() sits along side the other services like eventBus, announce etc so that any plugin can get another plugins API methods. This should mean that we don't have to use the callbacks unless it needed. And cross plugin functionality can be encapsulated inside a plugin etc...