### PR TITLE
Screen reader only shortcuts supported

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -478,6 +478,8 @@ Whether map text labels can be selected and read aloud by assistive technologies
 
 A function that returns a reverse geocode provider used to convert map coordinates to a place name, for example when announcing the current map position to screen reader users. Like the map provider, it is only called when the map is opened so the provider code is not sent to the user unless needed.
 
+When set, this also enables a <kbd>Option</kbd>/<kbd>Alt</kbd> + <kbd>I</kbd> (<kbd>Ctrl</kbd> + <kbd>I</kbd> on Windows/Linux — Alt+letter is reserved there for browser/OS menu mnemonics) keyboard shortcut that announces the place name at the map's current centre along with the visible area's dimensions. It has no visual affordance, so its keyboard shortcuts help panel entry is screen-reader-only.
+
 ```js
 new InteractiveMap('map', {
   reverseGeocodeProvider: openNamesProvider()

--- a/docs/api/keyboard-shortcut-definition.md
+++ b/docs/api/keyboard-shortcut-definition.md
@@ -1,0 +1,102 @@
+# KeyboardShortcutDefinition
+
+Describes a single row in the keyboard shortcuts help panel (opened via <kbd>Shift</kbd> + <kbd>?</kbd>). Plugins register these via [PluginManifest](../plugins/plugin-manifest.md)'s `keyboardShortcuts`; the app's own built-in shortcuts use this same shape internally.
+
+Registering a `KeyboardShortcutDefinition` only adds a row to the help panel — it does **not** bind the key itself. Wire up the actual keydown/keyup handling separately (e.g. in your plugin's `InitComponent`) and use the same key combination in both places.
+
+## Properties
+
+---
+
+### `id`
+**Type:** `string`
+**Required**
+
+Unique shortcut identifier. Re-registering with an id already used by your plugin replaces that entry.
+
+---
+
+### `title`
+**Type:** `string`
+**Required**
+
+Accessible title shown in the help panel.
+
+---
+
+### `command`
+**Type:** `string`
+**Required**
+
+HTML string describing the key combination, wrapped in `<kbd>` tags:
+
+```js
+{
+  id: 'myPluginAction',
+  title: 'Do the thing',
+  command: '<kbd>Shift</kbd> + <kbd>X</kbd>'
+}
+```
+
+> [!TIP]
+> If your shortcut uses the Alt key, label it per platform — macOS keyboards and menus call it **Option**, not Alt (Windows/Linux keep Alt). Use the shared `isMac()` helper (`src/utils/isMac.js`) to build the label, the same way the app's own core shortcuts and the `draw` plugin's `drawUndo`/`drawSelectAdjacentPoint` entries do:
+>
+> ```js
+> import { isMac } from '../../src/utils/isMac.js'
+>
+> const altKeyHtml = isMac() ? '<kbd>Option</kbd>' : '<kbd>Alt</kbd>'
+>
+> // command: `${altKeyHtml} + <kbd>X</kbd>`
+> ```
+>
+> The same applies to Cmd/Ctrl-based shortcuts — see `drawUndo`'s `<kbd>Command</kbd> + <kbd>Z</kbd>` / `<kbd>Ctrl</kbd> + <kbd>Z</kbd>` for that pattern.
+
+---
+
+### `context`
+**Type:** `'viewport' | 'listbox' | 'global'`
+**Optional, default:** `'viewport'`
+
+Which help-panel context this shortcut applies to. This only affects which tab the panel opens on by default when it's shown — it doesn't affect whether the row itself is displayed.
+
+---
+
+### `group`
+**Type:** `string`
+**Optional, default:** `'Navigate'`
+
+Tab label the shortcut is grouped under in the help panel. Shortcuts sharing a group (case/whitespace-insensitive) appear together under one tab. If every visible shortcut ends up sharing a single group, the panel renders as a flat list with no tabs at all.
+
+---
+
+### `requiredConfig`
+**Type:** `string[]`
+**Optional**
+
+App config keys that must all be truthy for the shortcut to appear in the help panel. Useful when your shortcut only does something meaningful once a related config option is set:
+
+```js
+{
+  id: 'myPluginAction',
+  title: 'Do the thing',
+  command: '<kbd>Shift</kbd> + <kbd>X</kbd>',
+  requiredConfig: ['myPluginFeatureEnabled']
+}
+```
+
+---
+
+### `visuallyHidden`
+**Type:** `boolean`
+**Optional, default:** `false`
+
+When true, the row is hidden from sighted users (it stays in the DOM with a visually-hidden style) but remains discoverable by assistive technology. Use this for a shortcut with no visual affordance to discover it by otherwise — for example, one whose only effect is a screen reader announcement:
+
+```js
+{
+  id: 'myPluginAction',
+  title: 'Announce something useful',
+  command: '<kbd>Shift</kbd> + <kbd>X</kbd>',
+  visuallyHidden: true
+}
+```

--- a/docs/building-a-plugin.md
+++ b/docs/building-a-plugin.md
@@ -134,6 +134,7 @@ For detailed specifications, see:
 - [PanelDefinition](./api/panel-definition.md) - Panel configuration
 - [ControlDefinition](./api/control-definition.md) - Custom control configuration
 - [IconDefinition](./api/icon-definition.md) - Icon registration
+- [KeyboardShortcutDefinition](./api/keyboard-shortcut-definition.md) - Keyboard shortcut help panel entries
 - [Slots](./api/slots.md) - UI slot system for positioning elements
 
 ## Events

--- a/docs/plugins/draw.md
+++ b/docs/plugins/draw.md
@@ -402,7 +402,7 @@ The plugin registers its own toolbar buttons automatically — Cancel, Add point
 |----------|--------|
 | <kbd>Enter</kbd> | Add point (draw) |
 | <kbd>Spacebar</kbd> | Select nearest point (edit) |
-| <kbd>Alt</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>/<kbd>←</kbd>/<kbd>→</kbd> | Select adjacent point (edit) |
+| <kbd>Option</kbd>/<kbd>Alt</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>/<kbd>←</kbd>/<kbd>→</kbd> | Select adjacent point (edit) |
 | <kbd>↑</kbd>/<kbd>↓</kbd>/<kbd>←</kbd>/<kbd>→</kbd> | Move point (edit) |
 | <kbd>Shift</kbd> + <kbd>↑</kbd>/<kbd>↓</kbd>/<kbd>←</kbd>/<kbd>→</kbd> | Nudge point, fine step (edit) |
 | <kbd>Delete</kbd> | Delete point (edit) |

--- a/docs/plugins/plugin-manifest.md
+++ b/docs/plugins/plugin-manifest.md
@@ -87,6 +87,15 @@ const InitComponent = ({ context }) => {
 
 ---
 
+### `keyboardShortcuts`
+**Type:** `KeyboardShortcutDefinition[]`
+
+Keyboard shortcut definitions shown in the keyboard shortcuts help panel (opened via <kbd>Shift</kbd> + <kbd>?</kbd>). Registering one only adds a row to the help panel — bind the actual key handling separately, e.g. in your plugin's `InitComponent`.
+
+See [KeyboardShortcutDefinition](../api/keyboard-shortcut-definition.md) for full details.
+
+---
+
 ### `panels`
 **Type:** `PanelDefinition[]`
 

--- a/plugins/draw/src/manifest.js
+++ b/plugins/draw/src/manifest.js
@@ -20,6 +20,9 @@ const isEditMode = (mode) => EDIT_MODES.has(mode)
 
 // Show the platform-appropriate undo modifier (⌘ on macOS, Ctrl elsewhere).
 const undoCommand = isMac() ? '<kbd>Command</kbd> + <kbd>Z</kbd>' : '<kbd>Ctrl</kbd> + <kbd>Z</kbd>'
+// Show the platform-appropriate label for the Alt modifier — macOS keyboards and
+// menus call it Option, not Alt.
+const altKeyHtml = isMac() ? '<kbd>Option</kbd>' : '<kbd>Alt</kbd>'
 
 const createButtonSlots = (showLabel) => ({
   mobile: { slot: 'actions', showLabel },
@@ -131,7 +134,7 @@ export const manifest = {
     id: 'drawSelectAdjacentPoint',
     group: 'Drawing',
     title: 'Select adjacent point (edit)',
-    command: '<kbd>Alt</kbd> + <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> or <kbd>→</kbd>'
+    command: `${altKeyHtml} + <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> or <kbd>→</kbd>`
   }, {
     id: 'drawMovePoint',
     group: 'Drawing',

--- a/plugins/draw/src/manifest.test.js
+++ b/plugins/draw/src/manifest.test.js
@@ -152,13 +152,13 @@ describe('drawMenu', () => {
   })
 })
 
-describe('drawUndo keyboard shortcut (platform-specific command)', () => {
-  const loadUndoCommand = (mac) => {
+describe('platform-specific keyboard shortcut commands', () => {
+  const loadCommand = (mac, id) => {
     let command
     jest.isolateModules(() => {
       jest.doMock('../../../src/utils/isMac.js', () => ({ isMac: () => mac }))
       const { manifest: reloaded } = require('./manifest.js')
-      command = reloaded.keyboardShortcuts.find((s) => s.id === 'drawUndo').command
+      command = reloaded.keyboardShortcuts.find((s) => s.id === id).command
     })
     return command
   }
@@ -168,11 +168,23 @@ describe('drawUndo keyboard shortcut (platform-specific command)', () => {
     jest.resetModules()
   })
 
-  test('uses Command on macOS', () => {
-    expect(loadUndoCommand(true)).toBe('<kbd>Command</kbd> + <kbd>Z</kbd>')
+  describe('drawUndo', () => {
+    test('uses Command on macOS', () => {
+      expect(loadCommand(true, 'drawUndo')).toBe('<kbd>Command</kbd> + <kbd>Z</kbd>')
+    })
+
+    test('uses Ctrl on non-mac platforms', () => {
+      expect(loadCommand(false, 'drawUndo')).toBe('<kbd>Ctrl</kbd> + <kbd>Z</kbd>')
+    })
   })
 
-  test('uses Ctrl on non-mac platforms', () => {
-    expect(loadUndoCommand(false)).toBe('<kbd>Ctrl</kbd> + <kbd>Z</kbd>')
+  describe('drawSelectAdjacentPoint', () => {
+    test('uses Option on macOS', () => {
+      expect(loadCommand(true, 'drawSelectAdjacentPoint')).toBe('<kbd>Option</kbd> + <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> or <kbd>→</kbd>')
+    })
+
+    test('uses Alt on non-mac platforms', () => {
+      expect(loadCommand(false, 'drawSelectAdjacentPoint')).toBe('<kbd>Alt</kbd> + <kbd>↑</kbd> <kbd>↓</kbd> <kbd>←</kbd> or <kbd>→</kbd>')
+    })
   })
 })

--- a/src/App/components/KeyboardHelp/KeyboardHelp.jsx
+++ b/src/App/components/KeyboardHelp/KeyboardHelp.jsx
@@ -10,7 +10,10 @@ const DEFAULT_GROUP = 'Navigate'
 const ShortcutList = ({ items }) => (
   <dl className='im-c-keyboard-help__list'>
     {items.map((item) => (
-      <div key={item.id} className='im-c-keyboard-help__item'>
+      <div
+        key={item.id}
+        className={`im-c-keyboard-help__item${item.visuallyHidden ? ' im-u-visually-hidden' : ''}`}
+      >
         <dt className='im-c-keyboard-help__title'>{item.title}</dt>
         <dd className='im-c-keyboard-help__description' dangerouslySetInnerHTML={{ __html: item.command }} />
       </div>

--- a/src/App/components/KeyboardHelp/KeyboardHelp.test.jsx
+++ b/src/App/components/KeyboardHelp/KeyboardHelp.test.jsx
@@ -68,6 +68,23 @@ describe('KeyboardHelp — flat list', () => {
     render(<KeyboardHelp />)
     expect(screen.getByText('↑')).toBeInTheDocument()
   })
+
+  it('visually hides a shortcut flagged visuallyHidden but keeps it in the DOM for assistive tech', () => {
+    getKeyboardShortcuts.mockReturnValue([
+      ...VIEWPORT_SHORTCUTS,
+      { id: 'sr', context: 'viewport', title: 'Get info', command: '<kbd>Alt</kbd> + <kbd>I</kbd>', visuallyHidden: true }
+    ])
+    render(<KeyboardHelp />)
+    const item = screen.getByText('Get info').closest('.im-c-keyboard-help__item')
+    expect(item).toHaveClass('im-u-visually-hidden')
+  })
+
+  it('does not visually hide a regular shortcut', () => {
+    getKeyboardShortcuts.mockReturnValue(VIEWPORT_SHORTCUTS)
+    render(<KeyboardHelp />)
+    const item = screen.getByText('Move').closest('.im-c-keyboard-help__item')
+    expect(item).not.toHaveClass('im-u-visually-hidden')
+  })
 })
 
 // ─── tab UI (multiple groups) ─────────────────────────────────────────────────

--- a/src/App/controls/keyboardMappings.js
+++ b/src/App/controls/keyboardMappings.js
@@ -1,3 +1,8 @@
+import { isMac } from '../../utils/isMac.js'
+
+// getInfo uses Ctrl on Windows/Linux (Alt+letter is reserved for menu mnemonics there) and Alt/Option on Mac — keep in sync with keyboardShortcuts.js's `infoKeyHtml`.
+const infoModifier = isMac() ? 'Alt' : 'Ctrl'
+
 export const keyboardMappings = {
   keydown: {
     ArrowUp: 'panUp',
@@ -17,8 +22,8 @@ export const keyboardMappings = {
     'Alt+ArrowUp': 'highlightNextLabel',
     'Alt+ArrowDown': 'highlightNextLabel',
     'Alt+Enter': 'highlightLabelAtCenter',
-    'Alt+i': 'getInfo',
-    'Alt+I': 'getInfo',
+    [`${infoModifier}+i`]: 'getInfo',
+    [`${infoModifier}+I`]: 'getInfo',
     Escape: 'clearSelection'
   }
 }

--- a/src/App/controls/keyboardMappings.test.js
+++ b/src/App/controls/keyboardMappings.test.js
@@ -1,0 +1,21 @@
+describe('keyboardMappings', () => {
+  beforeEach(() => jest.resetModules())
+
+  const load = () => require('./keyboardMappings.js').keyboardMappings
+
+  it('binds getInfo to Alt+i/Alt+I on Mac', () => {
+    Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true })
+    const { keyup } = load()
+    expect(keyup['Alt+i']).toBe('getInfo')
+    expect(keyup['Alt+I']).toBe('getInfo')
+    expect(keyup['Ctrl+i']).toBeUndefined()
+  })
+
+  it('binds getInfo to Ctrl+i/Ctrl+I on non-Mac', () => {
+    Object.defineProperty(navigator, 'platform', { value: 'Win32', configurable: true })
+    const { keyup } = load()
+    expect(keyup['Ctrl+i']).toBe('getInfo')
+    expect(keyup['Ctrl+I']).toBe('getInfo')
+    expect(keyup['Alt+i']).toBeUndefined()
+  })
+})

--- a/src/App/controls/keyboardShortcuts.js
+++ b/src/App/controls/keyboardShortcuts.js
@@ -1,6 +1,9 @@
 // src/controls/keyboardShortcuts.js
-const isMac = /mac/i.test(navigator.userAgentData?.platform ?? navigator.platform)
-const altKeyHtml = isMac ? '<kbd>Option</kbd>' : '<kbd>Alt</kbd>'
+import { isMac } from '../../utils/isMac.js'
+
+const altKeyHtml = isMac() ? '<kbd>Option</kbd>' : '<kbd>Alt</kbd>'
+// getInfo uses Ctrl on Windows/Linux instead of Alt, which is reserved there for menu mnemonics.
+const infoKeyHtml = isMac() ? '<kbd>Option</kbd>' : '<kbd>Ctrl</kbd>'
 
 export const coreShortcuts = [
   {
@@ -9,6 +12,17 @@ export const coreShortcuts = [
     command: '<kbd>Shift</kbd> + <kbd>?</kbd>',
     context: 'global',
     enabled: true
+  },
+  {
+    id: 'getInfo',
+    title: 'Get current location and visible area',
+    command: `${infoKeyHtml} + <kbd>I</kbd>`,
+    enabled: true,
+    // No visual equivalent, so hide the row from sighted users but keep it discoverable via assistive tech.
+    visuallyHidden: true,
+    // Only needs getCenter/getZoom, which every map provider implements, so no adapter needs to declare it.
+    mapProviderAgnostic: true,
+    requiredConfig: ['reverseGeocodeProvider']
   },
   {
     id: 'moveLarge',

--- a/src/App/controls/keyboardShortcuts.test.js
+++ b/src/App/controls/keyboardShortcuts.test.js
@@ -21,4 +21,25 @@ describe('keyboardShortcuts', () => {
       expect(s.command).toContain('<kbd>Alt</kbd>')
     })
   })
+
+  it('marks getInfo as visuallyHidden, map-provider-agnostic and requiring reverseGeocodeProvider', () => {
+    const shortcuts = load()
+    const getInfo = shortcuts.find(s => s.id === 'getInfo')
+    expect(getInfo).toMatchObject({
+      visuallyHidden: true,
+      mapProviderAgnostic: true,
+      requiredConfig: ['reverseGeocodeProvider']
+    })
+  })
+
+  it('uses Ctrl for getInfo on non-Mac and Option on Mac', () => {
+    Object.defineProperty(navigator, 'platform', { value: 'MacIntel', configurable: true })
+    let getInfo = load().find(s => s.id === 'getInfo')
+    expect(getInfo.command).toContain('<kbd>Option</kbd>')
+
+    jest.resetModules()
+    Object.defineProperty(navigator, 'platform', { value: 'Win32', configurable: true })
+    getInfo = load().find(s => s.id === 'getInfo')
+    expect(getInfo.command).toContain('<kbd>Ctrl</kbd>')
+  })
 })

--- a/src/App/hooks/useKeyboardShortcuts.js
+++ b/src/App/hooks/useKeyboardShortcuts.js
@@ -46,7 +46,15 @@ export function useKeyboardShortcuts (containerRef) {
         // No action
       }
 
-      return e.altKey ? `Alt+${key}` : key
+      // Check altKey first: AltGr (used on many non-US keyboards) reports both altKey
+      // and ctrlKey as true, and should still resolve to the Alt+ binding, not Ctrl+.
+      if (e.altKey) {
+        return `Alt+${key}`
+      }
+      if (e.ctrlKey) {
+        return `Ctrl+${key}`
+      }
+      return key
     }
 
     const handle = (type) => (e) => {

--- a/src/App/hooks/useKeyboardShortcuts.test.js
+++ b/src/App/hooks/useKeyboardShortcuts.test.js
@@ -138,6 +138,29 @@ describe('useKeyboardShortcuts', () => {
     expect(actions.stopPan).toHaveBeenCalled()
   })
 
+  test('normalizes Ctrl+key combinations', () => {
+    const { containerRef, actions } = setup({
+      keydown: { 'Ctrl+I': 'getInfo' },
+      actions: { getInfo: jest.fn() }
+    })
+    renderHook(() => useKeyboardShortcuts(containerRef))
+
+    containerRef.current.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyI', key: 'i', ctrlKey: true }))
+    expect(actions.getInfo).toHaveBeenCalled()
+  })
+
+  test('treats AltGr (altKey + ctrlKey both true) as Alt+, not Ctrl+', () => {
+    const { containerRef, actions } = setup({
+      keydown: { 'Alt+I': 'getInfo', 'Ctrl+I': 'zoomIn' },
+      actions: { getInfo: jest.fn(), zoomIn: jest.fn() }
+    })
+    renderHook(() => useKeyboardShortcuts(containerRef))
+
+    containerRef.current.dispatchEvent(new KeyboardEvent('keydown', { code: 'KeyI', key: 'i', altKey: true, ctrlKey: true }))
+    expect(actions.getInfo).toHaveBeenCalled()
+    expect(actions.zoomIn).not.toHaveBeenCalled()
+  })
+
   test('prevents default when action exists, does nothing otherwise', () => {
     const { containerRef } = setup({ keydown: { I: 'zoomIn', X: 'nonExistent' } })
     renderHook(() => useKeyboardShortcuts(containerRef))

--- a/src/App/registry/keyboardShortcutRegistry.js
+++ b/src/App/registry/keyboardShortcutRegistry.js
@@ -19,8 +19,8 @@ const _setProviderSupportedShortcuts = (state, ids = []) => {
 
 const _getKeyboardShortcuts = (state, appConfig = {}) => {
   const filteredCore = coreShortcuts.filter(s => {
-    // Must be supported by provider
-    if (!state.providerSupportedIds.has(s.id)) {
+    // Must be supported by the map provider, unless the shortcut is map-provider-agnostic (no capability dependency, so no adapter needs to declare it).
+    if (!s.mapProviderAgnostic && !state.providerSupportedIds.has(s.id)) {
       return false
     }
     // Check requiredConfig - all specified config values must be truthy

--- a/src/App/registry/keyboardShortcutRegistry.test.js
+++ b/src/App/registry/keyboardShortcutRegistry.test.js
@@ -93,6 +93,22 @@ describe('createKeyboardShortcutRegistry', () => {
     ])
   })
 
+  test('a mapProviderAgnostic core shortcut is included even when no provider declares support for it', () => {
+    jest.resetModules()
+    jest.doMock('../controls/keyboardShortcuts.js', () => ({
+      coreShortcuts: [
+        { id: 'ordinary', description: 'Ordinary' },
+        { id: 'agnostic', description: 'Agnostic', mapProviderAgnostic: true }
+      ]
+    }))
+    const registry = require('./keyboardShortcutRegistry.js').createKeyboardShortcutRegistry()
+    registry.setProviderSupportedShortcuts([]) // no provider support declared at all
+
+    expect(registry.getKeyboardShortcuts()).toEqual([
+      { id: 'agnostic', description: 'Agnostic', mapProviderAgnostic: true }
+    ])
+  })
+
   test('two registry instances are fully isolated from each other', () => {
     // This is the multi-map-on-a-page scenario: a shortcut registered by one map
     // (e.g. a plugin) must never leak into another map's help panel, and each map's

--- a/src/types.js
+++ b/src/types.js
@@ -630,6 +630,43 @@
  */
 
 /**
+ * Describes a single row in the keyboard shortcuts help panel (opened via Shift+?).
+ * Plugins register these via `PluginManifest.keyboardShortcuts`; core (built-in)
+ * shortcuts share this same shape internally.
+ *
+ * @typedef {Object} KeyboardShortcutDefinition
+ *
+ * @property {string} command
+ * HTML string describing the key combination, rendered as markup — wrap keys in
+ * `<kbd>` tags, e.g. `'<kbd>Shift</kbd> + <kbd>K</kbd>'`. If it uses the Alt key,
+ * label it per platform (macOS calls it Option, not Alt) — see the shared `isMac()`
+ * helper and its use in the app's own core shortcuts.
+ *
+ * @property {'viewport' | 'listbox' | 'global'} [context='viewport']
+ * Which help-panel context this shortcut applies to. Used only to choose the panel's
+ * default open tab — it doesn't affect whether the row is shown.
+ *
+ * @property {string} [group='Navigate']
+ * Tab label the shortcut is grouped under in the help panel. Shortcuts sharing a group
+ * (case/whitespace-insensitive) appear together under one tab; if every visible shortcut
+ * shares one group, the panel renders as a flat list with no tabs.
+ *
+ * @property {string} id
+ * Unique shortcut identifier.
+ *
+ * @property {string[]} [requiredConfig]
+ * App config keys that must all be truthy for the shortcut to appear in the help panel.
+ *
+ * @property {string} title
+ * Accessible title shown in the help panel.
+ *
+ * @property {boolean} [visuallyHidden=false]
+ * When true, the row is hidden from sighted users but stays in the DOM and remains
+ * discoverable by assistive technology. Use for a shortcut with no visual affordance to
+ * discover it by otherwise — e.g. one whose only effect is a screen reader announcement.
+ */
+
+/**
  * Manifest defining a plugin's buttons, panels, controls, API methods, and state.
  *
  * @typedef {Object} PluginManifest
@@ -648,6 +685,9 @@
  *
  * @property {ComponentType} [InitComponent]
  * Initialization component.
+ *
+ * @property {KeyboardShortcutDefinition[]} [keyboardShortcuts]
+ * Keyboard shortcut definitions shown in the keyboard shortcuts help panel.
  *
  * @property {PanelDefinition[]} [panels]
  * Panel definitions.


### PR DESCRIPTION
When enabling the reverseGeocode service a screen reader only shortcut is registered to provide the necessary instruction to screen reader users. Also Alt replace with Option for Mac users as this is the correct key.