### PR TITLE
Prevent Alt+Arrow page scroll while navigating map labels

### DIFF
--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -284,7 +284,7 @@ const interactiveMap = new InteractiveMap('map', {
   containerHeight: '650px',
   transformRequest: transformVtsRequest3857,
   enableZoomControls: false,
-  // readMapText: true,
+  readMapText: true,
   // urlPosition: 'none',
   enableFullscreen: true,
   // hasExitButton: true,

--- a/plugins/interact/src/events.js
+++ b/plugins/interact/src/events.js
@@ -12,11 +12,15 @@ const createFeatureHandler = (mapState, getPluginState) => (args, addToExisting)
   })
 }
 
+// A modified Enter (Alt+Enter, Ctrl+Enter, etc.) is a different shortcut, not a
+// select-at-target trigger — e.g. Alt+Enter is core's highlightLabelAtCenter.
+const isPlainEnter = (event) => event.key === 'Enter' && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey
+
 const createKeyboardHandlers = (viewportRef, onSelectAtTarget) => {
   let enterOnViewport = false
-  const handleKeydown = (event) => { enterOnViewport = event.key === 'Enter' && viewportRef.current === event.target }
+  const handleKeydown = (event) => { enterOnViewport = isPlainEnter(event) && viewportRef.current === event.target }
   const handleKeyup = (event) => {
-    if (event.key === 'Enter' && enterOnViewport) {
+    if (isPlainEnter(event) && enterOnViewport) {
       event.preventDefault()
       onSelectAtTarget()
     }

--- a/plugins/interact/src/events.test.js
+++ b/plugins/interact/src/events.test.js
@@ -45,6 +45,38 @@ describe('attachEvents — keyboard', () => {
     expect(params.handleInteraction).toHaveBeenCalled()
   })
 
+  it('ignores Alt+Enter (a different shortcut, e.g. highlightLabelAtCenter) on viewport', () => {
+    const params = createParams()
+    cleanup = attachEvents(params)
+
+    const keydown = new KeyboardEvent('keydown', { key: 'Enter', altKey: true })
+    Object.defineProperty(keydown, 'target', { value: document.body })
+    document.dispatchEvent(keydown)
+
+    const keyup = new KeyboardEvent('keyup', { key: 'Enter', altKey: true })
+    Object.defineProperty(keyup, 'target', { value: document.body })
+    document.dispatchEvent(keyup)
+
+    expect(params.handleInteraction).not.toHaveBeenCalled()
+  })
+
+  it('ignores other modified Enter combinations (Ctrl/Meta/Shift+Enter) on viewport', () => {
+    const params = createParams()
+    cleanup = attachEvents(params)
+
+    ;['ctrlKey', 'metaKey', 'shiftKey'].forEach((modifier) => {
+      const keydown = new KeyboardEvent('keydown', { key: 'Enter', [modifier]: true })
+      Object.defineProperty(keydown, 'target', { value: document.body })
+      document.dispatchEvent(keydown)
+
+      const keyup = new KeyboardEvent('keyup', { key: 'Enter', [modifier]: true })
+      Object.defineProperty(keyup, 'target', { value: document.body })
+      document.dispatchEvent(keyup)
+    })
+
+    expect(params.handleInteraction).not.toHaveBeenCalled()
+  })
+
   it('ignores Enter outside viewport or other keys', () => {
     const params = createParams()
     cleanup = attachEvents(params)

--- a/src/App/hooks/useKeyboardShortcuts.js
+++ b/src/App/hooks/useKeyboardShortcuts.js
@@ -49,16 +49,33 @@ export function useKeyboardShortcuts (containerRef) {
       return e.altKey ? `Alt+${key}` : key
     }
 
-    const handle = (type) => (e) => {
-      const actionName = keyboardMappings[type][normalizeKey(e)]
-      if (actionName && actions[actionName]) {
+    const resolveAction = (type, key) => {
+      const actionName = keyboardMappings[type][key]
+      return actionName && actions[actionName] ? actionName : null
+    }
+
+    const handleKeyDown = (e) => {
+      const key = normalizeKey(e)
+      const actionName = resolveAction('keydown', key)
+      if (actionName) {
         actions[actionName](e)
+        e.preventDefault()
+        return
+      }
+      // A keyup-bound shortcut (e.g. Alt+Arrow label navigation) still acts on release,
+      // but its browser default (e.g. arrow-key scroll) must be suppressed now or it's too late.
+      if (resolveAction('keyup', key)) {
         e.preventDefault()
       }
     }
 
-    const handleKeyDown = handle('keydown')
-    const handleKeyUp = handle('keyup')
+    const handleKeyUp = (e) => {
+      const actionName = resolveAction('keyup', normalizeKey(e))
+      if (actionName) {
+        actions[actionName](e)
+        e.preventDefault()
+      }
+    }
 
     // keydown (pan/zoom) stays on the viewport so arrows only fire when the map has focus.
     // keyup (Alt+K and other global shortcuts) attaches to the app container so it fires

--- a/src/App/hooks/useKeyboardShortcuts.js
+++ b/src/App/hooks/useKeyboardShortcuts.js
@@ -5,6 +5,71 @@ import { useConfig } from '../store/configContext.js'
 import { useApp } from '../store/appContext.js'
 import { useService } from '../store/serviceContext.js'
 
+const normalizeKey = (e) => {
+  let key
+
+  // Use e.code for letters to avoid 'dead' keys with Alt/AltGr
+  if (/^Key[A-Z]$/.test(e.code)) {
+    key = e.code.slice(3) // NOSONAR: strip "Key" prefix, e.g. "KeyI" -> "I"
+  } else {
+    key = e.key // works for arrows, numpad, punctuation
+  }
+
+  // Normalize numpad add/subtract to symbols
+  if (key === 'Add' || key === 'NumpadAdd') {
+    key = '+'
+  } else if (key === 'Subtract' || key === 'NumpadSubtract') {
+    key = '-'
+  } else {
+    // No action
+  }
+
+  // Check altKey first: AltGr (used on many non-US keyboards) reports both altKey
+  // and ctrlKey as true, and should still resolve to the Alt+ binding, not Ctrl+.
+  if (e.altKey) {
+    return `Alt+${key}`
+  }
+  if (e.ctrlKey) {
+    return `Ctrl+${key}`
+  }
+  return key
+}
+
+const resolveAction = (actions, type, key) => {
+  const actionName = keyboardMappings[type][key]
+  return actionName && actions[actionName] ? actionName : null
+}
+
+// keydown (pan/zoom) stays on the viewport so arrows only fire when the map has focus.
+// keyup (Alt+K and other global shortcuts) attaches to the app container so it fires
+// from anywhere within the app, including the features listbox.
+const createKeyEventHandlers = (actions) => {
+  const handleKeyDown = (e) => {
+    const key = normalizeKey(e)
+    const actionName = resolveAction(actions, 'keydown', key)
+    if (actionName) {
+      actions[actionName](e)
+      e.preventDefault()
+      return
+    }
+    // A keyup-bound shortcut (e.g. Alt+Arrow label navigation) still acts on release,
+    // but its browser default (e.g. arrow-key scroll) must be suppressed now or it's too late.
+    if (resolveAction(actions, 'keyup', key)) {
+      e.preventDefault()
+    }
+  }
+
+  const handleKeyUp = (e) => {
+    const actionName = resolveAction(actions, 'keyup', normalizeKey(e))
+    if (actionName) {
+      actions[actionName](e)
+      e.preventDefault()
+    }
+  }
+
+  return { handleKeyDown, handleKeyUp }
+}
+
 export function useKeyboardShortcuts (containerRef) {
   const { mapProvider, panDelta, nudgePanDelta, zoomDelta, nudgeZoomDelta, readMapText } = useConfig()
   const { dispatch, layoutRefs } = useApp()
@@ -27,67 +92,8 @@ export function useKeyboardShortcuts (containerRef) {
       readMapText
     })
 
-    const normalizeKey = (e) => {
-      let key
+    const { handleKeyDown, handleKeyUp } = createKeyEventHandlers(actions)
 
-      // Use e.code for letters to avoid 'dead' keys with Alt/AltGr
-      if (/^Key[A-Z]$/.test(e.code)) {
-        key = e.code.slice(3) // NOSONAR: strip "Key" prefix, e.g. "KeyI" -> "I"
-      } else {
-        key = e.key // works for arrows, numpad, punctuation
-      }
-
-      // Normalize numpad add/subtract to symbols
-      if (key === 'Add' || key === 'NumpadAdd') {
-        key = '+'
-      } else if (key === 'Subtract' || key === 'NumpadSubtract') {
-        key = '-'
-      } else {
-        // No action
-      }
-
-      // Check altKey first: AltGr (used on many non-US keyboards) reports both altKey
-      // and ctrlKey as true, and should still resolve to the Alt+ binding, not Ctrl+.
-      if (e.altKey) {
-        return `Alt+${key}`
-      }
-      if (e.ctrlKey) {
-        return `Ctrl+${key}`
-      }
-      return key
-    }
-
-    const resolveAction = (type, key) => {
-      const actionName = keyboardMappings[type][key]
-      return actionName && actions[actionName] ? actionName : null
-    }
-
-    const handleKeyDown = (e) => {
-      const key = normalizeKey(e)
-      const actionName = resolveAction('keydown', key)
-      if (actionName) {
-        actions[actionName](e)
-        e.preventDefault()
-        return
-      }
-      // A keyup-bound shortcut (e.g. Alt+Arrow label navigation) still acts on release,
-      // but its browser default (e.g. arrow-key scroll) must be suppressed now or it's too late.
-      if (resolveAction('keyup', key)) {
-        e.preventDefault()
-      }
-    }
-
-    const handleKeyUp = (e) => {
-      const actionName = resolveAction('keyup', normalizeKey(e))
-      if (actionName) {
-        actions[actionName](e)
-        e.preventDefault()
-      }
-    }
-
-    // keydown (pan/zoom) stays on the viewport so arrows only fire when the map has focus.
-    // keyup (Alt+K and other global shortcuts) attaches to the app container so it fires
-    // from anywhere within the app, including the features listbox.
     el.addEventListener('keydown', handleKeyDown)
     appEl.addEventListener('keyup', handleKeyUp)
 

--- a/src/App/hooks/useKeyboardShortcuts.test.js
+++ b/src/App/hooks/useKeyboardShortcuts.test.js
@@ -138,6 +138,35 @@ describe('useKeyboardShortcuts', () => {
     expect(actions.stopPan).toHaveBeenCalled()
   })
 
+  test('does nothing on keyup when the key has no mapped action', () => {
+    const { appContainerRef, actions } = setup({ keyup: { ArrowUp: 'stopPan' }, actions: { stopPan: jest.fn() } })
+    renderHook(() => useKeyboardShortcuts({ current: document.createElement('div') }))
+
+    const evt = new KeyboardEvent('keyup', { key: 'Z' })
+    const spy = jest.spyOn(evt, 'preventDefault')
+    appContainerRef.current.dispatchEvent(evt)
+
+    expect(spy).not.toHaveBeenCalled()
+    expect(actions.stopPan).not.toHaveBeenCalled()
+  })
+
+  test('suppresses the browser default on keydown for a keyup-bound shortcut, without firing the action early', () => {
+    const { containerRef, appContainerRef, actions } = setup({
+      keyup: { 'Alt+ArrowUp': 'highlightNextLabel' },
+      actions: { highlightNextLabel: jest.fn() }
+    })
+    renderHook(() => useKeyboardShortcuts(containerRef))
+
+    const keydownEvt = new KeyboardEvent('keydown', { key: 'ArrowUp', altKey: true })
+    const keydownSpy = jest.spyOn(keydownEvt, 'preventDefault')
+    containerRef.current.dispatchEvent(keydownEvt)
+    expect(keydownSpy).toHaveBeenCalled()
+    expect(actions.highlightNextLabel).not.toHaveBeenCalled()
+
+    appContainerRef.current.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowUp', altKey: true }))
+    expect(actions.highlightNextLabel).toHaveBeenCalled()
+  })
+
   test('prevents default when action exists, does nothing otherwise', () => {
     const { containerRef } = setup({ keydown: { I: 'zoomIn', X: 'nonExistent' } })
     renderHook(() => useKeyboardShortcuts(containerRef))


### PR DESCRIPTION
When readMapText is true in the map options. Alt+cursor will attempt to navigate the map labels. However Alt+cursor up/down is also the default page scroll shortcut. This fix suppresses page scroll when navigating labels.