### PR TITLE
Aria panel props fix

### DIFF
--- a/plugins/search/src/manifest.js
+++ b/plugins/search/src/manifest.js
@@ -8,22 +8,18 @@ export const manifest = {
     actions
   },
 
-  // The open trigger is a standard MapButton so it inherits the shared tooltip
-  // (shown whenever its label is hidden). It toggles the plugin's own `isExpanded`
-  // state, which the `search` control below reads to reveal the form.
+  // Standard MapButton that toggles the plugin's own `isExpanded` state to reveal the form.
   buttons: [{
     id: 'search',
     label: 'Search',
     iconId: 'search',
-    // aria-controls the form rendered by the control (matches the form's id in Form.jsx)
+    // aria-controls the form rendered by the control
     ariaControls: ({ appConfig }) => `${appConfig.id}-search-form`,
+    // Mirrors isExpanded into appState so MapButton renders aria-expanded
+    expandedWhen: ({ pluginState }) => pluginState.isExpanded,
     // No trigger in default-expanded mode — the form is always visible there
     excludeWhen: ({ pluginConfig }) => Boolean(pluginConfig.expanded),
-    // Keep focus in the search (the control focuses the input on open) rather than
-    // letting the button return focus to the map viewport after the click.
-    // NB: the trigger is hidden while the form is open via the `im-o-app--exclusive-control`
-    // CSS (opacity + out-of-flow) rather than `hiddenWhen`, so it stays focusable and
-    // focus can be returned to it on close without a display:none race.
+    // Trigger stays hidden-but-focusable via CSS while open, so keep focus here rather than the viewport
     keepFocus: true,
     onClick: (_e, { pluginState, services }) => {
       pluginState.dispatch({ type: 'TOGGLE_EXPANDED', payload: true })

--- a/plugins/search/src/manifest.test.js
+++ b/plugins/search/src/manifest.test.js
@@ -24,6 +24,11 @@ describe('search manifest', () => {
     expect(getButton().ariaControls({ appConfig: { id: 'map' } })).toBe('map-search-form')
   })
 
+  it('mirrors pluginState.isExpanded for aria-expanded', () => {
+    expect(getButton().expandedWhen({ pluginState: { isExpanded: true } })).toBe(true)
+    expect(getButton().expandedWhen({ pluginState: { isExpanded: false } })).toBe(false)
+  })
+
   it('excludes the trigger in default-expanded mode', () => {
     expect(getButton().excludeWhen({ pluginConfig: { expanded: true } })).toBe(true)
     expect(getButton().excludeWhen({ pluginConfig: { expanded: false } })).toBe(false)

--- a/src/App/components/MapButton/MapButton.jsx
+++ b/src/App/components/MapButton/MapButton.jsx
@@ -89,6 +89,10 @@ const makePopupKeyUpHandler = (hasMenu, buttonRefs, buttonId, setMenuStartPos, s
 const getButtonSlot = (panelId, buttonId) =>
   panelId ? `${stringToKebab(buttonId)}-button` : undefined
 
+// aria-haspopup only accepts these role-shaped tokens (plus 'true', unused here) — any other
+// controlled-element role (e.g. a panel's 'complementary'/'region') means no aria-haspopup.
+const HASPOPUP_ROLES = new Set(['menu', 'listbox', 'tree', 'grid', 'dialog'])
+
 /**
  * Determines the controlled element (panel or popup menu) for ARIA attributes.
  * @param {Object} options - Configuration options
@@ -96,14 +100,16 @@ const getButtonSlot = (panelId, buttonId) =>
  * @param {string} options.panelId - ID of the controlled panel (if applicable)
  * @param {string} options.buttonId - Unique button identifier
  * @param {boolean} options.hasMenu - Whether the button has a popup menu
- * @returns {Object|null} Object with id and type ('panel' or 'popup'), or null if no controlled element
+ * @param {string} [options.panelRole] - The controlled panel's own ARIA role (see getPanelRole.js),
+ *   used for aria-haspopup on the button — undefined when no panel is controlled.
+ * @returns {Object|null} Object with id, type ('panel' or 'popup') and role, or null if no controlled element
  */
-const getControlledElement = ({ idPrefix, panelId, buttonId, hasMenu }) => {
+const getControlledElement = ({ idPrefix, panelId, buttonId, hasMenu, panelRole }) => {
   if (panelId) {
-    return { id: getPanelElementId(idPrefix, panelId), type: 'panel' }
+    return { id: getPanelElementId(idPrefix, panelId), type: 'panel', role: panelRole }
   }
   if (hasMenu) {
-    return { id: `${idPrefix}-popup-${stringToKebab(buttonId)}`, type: 'popup' }
+    return { id: `${idPrefix}-popup-${stringToKebab(buttonId)}`, type: 'popup', role: 'menu' }
   }
   return null
 }
@@ -169,7 +175,7 @@ const buildButtonProps = ({
     'aria-expanded': ariaExpanded,
     'aria-pressed': typeof isPressed === 'boolean' ? isPressed : undefined,
     'aria-controls': controlledElement?.id ?? ariaControls,
-    'aria-haspopup': controlledElement?.type === 'popup' ? 'menu' : undefined,
+    'aria-haspopup': HASPOPUP_ROLES.has(controlledElement?.role) ? controlledElement.role : undefined,
     ...(href
       ? { href, target: '_blank', onKeyUp: handleKeyUp, role: 'button' }
       : { type: 'button' })
@@ -192,6 +198,7 @@ const buildButtonProps = ({
  * @param {boolean} [props.isExpanded] - Whether content controlled by the button is expanded
  * @param {boolean} [props.isHidden=false] - Whether to hide the button (CSS display: none)
  * @param {boolean} [props.isPanelOpen=false] - Whether the controlled panel is open
+ * @param {string} [props.panelRole] - The controlled panel's own ARIA role, used for aria-haspopup
  * @param {string} [props.variant] - CSS variant class for styling (e.g., 'primary')
  * @param {Function} [props.onClick] - Custom click handler
  * @param {string} [props.panelId] - ID of the panel controlled by this button
@@ -213,6 +220,7 @@ export const MapButton = ({
   isExpanded,
   isHidden,
   isPanelOpen,
+  panelRole,
   variant,
   onClick,
   panelId,
@@ -240,7 +248,7 @@ export const MapButton = ({
   const hasMenu = menuItems?.length >= 1
   const showIcon = iconId || iconSvgContent || hasMenu
   const buttonSlot = getButtonSlot(panelId, buttonId)
-  const controlledElement = getControlledElement({ idPrefix, panelId, buttonId, hasMenu })
+  const controlledElement = getControlledElement({ idPrefix, panelId, buttonId, hasMenu, panelRole })
 
   /**
    * Handles button click events.

--- a/src/App/components/MapButton/MapButton.test.jsx
+++ b/src/App/components/MapButton/MapButton.test.jsx
@@ -83,7 +83,18 @@ describe('MapButton', () => {
     expect(button).toHaveAttribute('aria-expanded', 'false')
     expect(button).not.toHaveAttribute('aria-pressed')
     expect(button).toHaveAttribute('aria-controls', 'prefix-panel-settings')
+    expect(button).not.toHaveAttribute('aria-haspopup')
     expect(screen.getByTestId('slot')).toHaveAttribute('data-slot', 'test-button')
+  })
+
+  it('sets aria-haspopup="dialog" when the controlled panel is a dialog', () => {
+    renderButton({ panelId: 'Settings', idPrefix: 'prefix', panelRole: 'dialog' })
+    expect(getButton()).toHaveAttribute('aria-haspopup', 'dialog')
+  })
+
+  it.each(['complementary', 'region'])('sets no aria-haspopup when the controlled panel role is %s', (panelRole) => {
+    renderButton({ panelId: 'Settings', idPrefix: 'prefix', panelRole })
+    expect(getButton()).not.toHaveAttribute('aria-haspopup')
   })
 
   it.each([

--- a/src/App/components/Panel/Panel.jsx
+++ b/src/App/components/Panel/Panel.jsx
@@ -5,30 +5,15 @@ import { stringToKebab } from '../../../utils/stringToKebab.js'
 import { getPanelElementId } from '../../../utils/getPanelElementId.js'
 import { useModalPanelBehaviour } from '../../hooks/useModalPanelBehaviour.js'
 import { useIsScrollable } from '../../hooks/useIsScrollable.js'
+import { classifyPanel, getPanelRole } from '../../../utils/getPanelRole.js'
 import { Icon } from '../Icon/Icon'
 import { Tabs } from '../Tabs/Tabs.jsx'
 
-// WCAG requires a modal to always be dismissible, so modal:true forces it regardless of config.
-const resolveIsDismissible = (bpConfig, isModal) => isModal || bpConfig.dismissible !== false
-
 const computePanelState = (bpConfig, triggeringElement, focus, focusOnOpen) => {
-  const isModal = bpConfig.modal === true
-  const isAside = bpConfig.slot === 'side' && bpConfig.open && !isModal
-  const isDismissible = resolveIsDismissible(bpConfig, isModal)
-  const isDialog = !isAside && isDismissible
+  const { isModal, isAside, isDismissible, isDialog } = classifyPanel(bpConfig)
   const shouldFocus = isModal || focusOnOpen === true || (focusOnOpen !== false && focus !== false && (focus === true || Boolean(triggeringElement)))
   const buttonContainerEl = bpConfig.slot.endsWith('button') ? triggeringElement?.parentNode : undefined
   return { isAside, isDialog, isModal, isDismissible, shouldFocus, buttonContainerEl }
-}
-
-const getPanelRole = (isDialog, isDismissible) => {
-  if (isDialog) {
-    return 'dialog'
-  }
-  if (isDismissible) {
-    return 'complementary'
-  }
-  return 'region'
 }
 
 const buildPanelClassNames = (slot, showLabel) => [
@@ -46,7 +31,7 @@ const buildPanelProps = ({ elementId, shouldFocus, isDialog, isDismissible, isMo
   id: elementId,
   'aria-labelledby': `${elementId}-label`,
   tabIndex: shouldFocus ? -1 : undefined, // nosonar
-  role: getPanelRole(isDialog, isDismissible),
+  role: getPanelRole({ isDialog, isDismissible }),
   'aria-modal': isDialog && isModal ? 'true' : undefined,
   style: width ? { width } : undefined,
   className: panelClass,

--- a/src/App/hooks/useModalPanelBehaviour.js
+++ b/src/App/hooks/useModalPanelBehaviour.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useLayoutEffect } from 'react'
 import { useResizeObserver } from './useResizeObserver.js'
 import { constrainKeyboardFocus } from '../../utils/constrainKeyboardFocus.js'
 import { toggleInertElements } from '../../utils/toggleInertElements.js'
@@ -60,6 +60,44 @@ const setSlotCSSVar = (slot, layoutRefs, primaryMargin) => {
 
   root.style.setProperty(MODAL_INSET, `${relTop}px auto auto ${relLeft}px`)
   root.style.setProperty(MODAL_MAX_HEIGHT, `${mainRect.height - relTop - primaryMargin}px`)
+}
+
+// Computes and applies --modal-inset/--modal-max-height for the panel's current slot. Shared by
+// the resize observer (keeps position correct across later layout changes while open) and the
+// open-triggered layout effect below (panels stay permanently mounted — see mapPanels.js — so
+// opening one doesn't itself resize mainRef and wouldn't otherwise trigger a recalc).
+const recalcModalPosition = ({ isModal, mainRef, panelRef, buttonContainerEl, layoutRefs }) => {
+  if (!isModal || !mainRef.current) {
+    return
+  }
+
+  const root = document.documentElement
+  const styles = getComputedStyle(root)
+  const dividerGap = Number.parseInt(styles.getPropertyValue('--divider-gap'), 10)
+  const primaryMargin = Number.parseInt(styles.getPropertyValue('--primary-gap'), 10)
+  const slot = panelRef.current.dataset.slot
+
+  // Button-adjacent panels: position next to the controlling button.
+  // Use slot name (not buttonContainerEl) as the gate — buttonContainerEl may be undefined
+  // when there is no triggeringElement (e.g. panel opened programmatically).
+  // Dynamically query via aria-controls to handle stale triggeringElement after breakpoint changes.
+  if (slot?.endsWith('-button')) {
+    const panelElId = panelRef.current?.id
+    const currentButtonEl = panelElId ? document.querySelector(`[aria-controls="${panelElId}"]`) : null
+    const effectiveContainer = currentButtonEl?.parentElement ??
+      (buttonContainerEl?.isConnected ? buttonContainerEl : null) ??
+      document.querySelector(`[data-button-slot="${slot}"]`)
+
+    if (!effectiveContainer) {
+      return
+    }
+
+    setButtonCSSVar(effectiveContainer, mainRef, dividerGap)
+    return
+  }
+
+  // Slot-based panels: derive position from the slot container element
+  setSlotCSSVar(slot, layoutRefs, primaryMargin)
 }
 
 const useModalKeyHandler = (panelRef, isModal, handleClose) => {
@@ -131,40 +169,16 @@ export function useModalPanelBehaviour ({
 
   useModalKeyHandler(panelRef, isModal, handleClose)
 
-  // === Set --modal-inset and --modal-max-height, recalculate on mainRef resize === //
-  useResizeObserver([mainRef], () => {
-    if (!isModal || !mainRef.current) {
-      return
-    }
+  // === Recalculate on mainRef resize (keeps position correct while already open) === //
+  useResizeObserver([mainRef], () => recalcModalPosition({ isModal, mainRef, panelRef, buttonContainerEl, layoutRefs }))
 
-    const root = document.documentElement
-    const styles = getComputedStyle(root)
-    const dividerGap = Number.parseInt(styles.getPropertyValue('--divider-gap'), 10)
-    const primaryMargin = Number.parseInt(styles.getPropertyValue('--primary-gap'), 10)
-    const slot = panelRef.current.dataset.slot
-
-    // Button-adjacent panels: position next to the controlling button.
-    // Use slot name (not buttonContainerEl) as the gate — buttonContainerEl may be undefined
-    // when there is no triggeringElement (e.g. panel opened programmatically).
-    // Dynamically query via aria-controls to handle stale triggeringElement after breakpoint changes.
-    if (slot?.endsWith('-button')) {
-      const panelElId = panelRef.current?.id
-      const currentButtonEl = panelElId ? document.querySelector(`[aria-controls="${panelElId}"]`) : null
-      const effectiveContainer = currentButtonEl?.parentElement ??
-        (buttonContainerEl?.isConnected ? buttonContainerEl : null) ??
-        document.querySelector(`[data-button-slot="${slot}"]`)
-
-      if (!effectiveContainer) {
-        return
-      }
-
-      setButtonCSSVar(effectiveContainer, mainRef, dividerGap)
-      return
-    }
-
-    // Slot-based panels: derive position from the slot container element
-    setSlotCSSVar(slot, layoutRefs, primaryMargin)
-  })
+  // === Recalculate the moment the panel opens === //
+  // The resize observer above won't fire on its own here: its size cache persists across
+  // opens/closes (the panel no longer mounts fresh each time), and opening a panel doesn't
+  // itself resize mainRef. This is what actually positions the panel at open time.
+  useLayoutEffect(() => {
+    recalcModalPosition({ isModal, mainRef, panelRef, buttonContainerEl, layoutRefs })
+  }, [isModal, mainRef, panelRef, buttonContainerEl, layoutRefs])
 
   // === Click on modal backdrop to close === //
   useEffect(() => {

--- a/src/App/hooks/useModalPanelBehaviour.test.js
+++ b/src/App/hooks/useModalPanelBehaviour.test.js
@@ -218,6 +218,65 @@ describe('useModalPanelBehaviour', () => {
     })
   })
 
+  // Regression: panels are mounted permanently and only toggle `hidden` (see mapPanels.js), so
+  // opening one doesn't itself resize mainRef. This uses the *real* useResizeObserver (backed by
+  // a fake ResizeObserver, not the blanket `(_, cb) => cb()` mock used above) so its size-change
+  // dedupe is actually exercised — that dedupe is what silently swallowed the reposition on open.
+  describe('repositioning on open when mainRef never resizes', () => {
+    const buttonSlot = 'map-styles-button'
+
+    beforeEach(() => {
+      const { useResizeObserver: actualUseResizeObserver } = jest.requireActual('./useResizeObserver.js')
+      useResizeObserverModule.useResizeObserver.mockImplementation(actualUseResizeObserver)
+
+      // Real ResizeObserver always delivers once per observe() call — mirror that, and let the
+      // real hook's own prevSizes dedupe decide whether the wrapped callback actually runs.
+      global.ResizeObserver = jest.fn(function (cb) {
+        this.observe = (target) => {
+          const entries = [{ target, contentRect: { width: 100, height: 50 } }]
+          cb(entries)
+        }
+        this.disconnect = jest.fn()
+      })
+      jest.spyOn(global, 'requestAnimationFrame').mockImplementation(cb => { cb(); return 0 })
+      jest.spyOn(global, 'cancelAnimationFrame').mockImplementation(() => {})
+      jest.spyOn(globalThis, 'getComputedStyle').mockReturnValue({ getPropertyValue: () => '8' })
+
+      Object.defineProperty(refs.main.current, 'getBoundingClientRect', {
+        value: () => ({ top: 0, right: 100, bottom: 50, left: 0, width: 100, height: 50 }),
+        configurable: true
+      })
+      Object.defineProperty(elements.buttonContainer, 'getBoundingClientRect', {
+        value: () => ({ top: 10, right: 80, bottom: 40, left: 20, width: 60, height: 30 }),
+        configurable: true
+      })
+
+      refs.panel.current.dataset.slot = buttonSlot
+      const button = document.createElement('button')
+      button.setAttribute(ARIA_CONTROLS, PANEL_ID)
+      elements.buttonContainer.appendChild(button)
+      document.body.appendChild(elements.buttonContainer)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('positions the panel the moment it opens, not just when mainRef resizes', () => {
+      // Mounted closed, as it would be permanently — mainRef's size gets recorded but the
+      // calc no-ops on the isModal guard.
+      const { rerender } = render(<TestComponent isModal={false} />)
+      expect(document.documentElement.style.getPropertyValue(MODAL_INSET)).toBe('')
+
+      // Open it. mainRef hasn't resized, so the resize observer's own delivery is deduped
+      // away — only the open-triggered layout effect can position it here.
+      rerender(<TestComponent isModal />)
+
+      expect(document.documentElement.style.getPropertyValue(MODAL_INSET)).toContain('10px')
+      expect(document.documentElement.style.getPropertyValue(MODAL_MAX_HEIGHT)).toContain('px')
+    })
+  })
+
   describe('focus management', () => {
     it('redirects focus into panel when focus enters app but outside panel', () => {
       refs.panel.current.focus = jest.fn()

--- a/src/App/renderer/mapButtons.js
+++ b/src/App/renderer/mapButtons.js
@@ -3,6 +3,7 @@ import { MapButton } from '../components/MapButton/MapButton.jsx'
 import { allowedSlots } from './slots.js'
 import { groupByKey } from './groupByKey.js'
 import { orderItems } from './orderItems.js'
+import { classifyPanel, getPanelRole } from '../../utils/getPanelRole.js'
 import { logger } from '../../services/logger.js'
 
 function getMatchingButtons ({ appState, buttonConfig, slot, evaluateProp }) {
@@ -118,6 +119,8 @@ function SlotButton ({ buttonId, config, appState, appConfig, evaluateProp }) {
   const bpConfig = config[appState.breakpoint] ?? {}
   const handleClick = createButtonClickHandler(config, appState, evaluateProp)
   const isPanelOpen = !!(config.panelId && appState.openPanels[config.panelId])
+  const panelBpConfig = config.panelId ? appState.panelConfig?.[config.panelId]?.[appState.breakpoint] : undefined
+  const panelRole = panelBpConfig ? getPanelRole(classifyPanel(panelBpConfig)) : undefined
 
   return (
     <MapButton
@@ -133,6 +136,7 @@ function SlotButton ({ buttonId, config, appState, appConfig, evaluateProp }) {
       isPressed={(config.isPressed !== undefined || config.pressedWhen) ? appState.pressedButtons.has(buttonId) : undefined}
       isExpanded={(config.isExpanded !== undefined || config.expandedWhen) ? appState.expandedButtons.has(buttonId) : undefined}
       isPanelOpen={isPanelOpen}
+      panelRole={panelRole}
       onClick={handleClick}
       panelId={config.panelId}
       menuItems={config.menuItems}

--- a/src/App/renderer/mapButtons.test.js
+++ b/src/App/renderer/mapButtons.test.js
@@ -170,6 +170,26 @@ describe('mapButtons module', () => {
       expect(result.props).toMatchObject({ isDisabled: true, isHidden: true, isPressed: true, isExpanded: true })
     })
 
+    it.each([
+      [{ slot: 'right-top', open: false }, 'dialog'],
+      [{ slot: 'right-top', open: false, dismissible: false }, 'region'],
+      [{ slot: 'side', open: true }, 'complementary']
+    ])('derives panelRole %j -> %s from the target panel\'s breakpoint config', (panelBpConfig, expectedRole) => {
+      const state = { ...appState, panelConfig: { p1: { desktop: panelBpConfig } } }
+      const result = render({ ...baseBtn, panelId: 'p1' }, state)
+      expect(result.props.panelRole).toBe(expectedRole)
+    })
+
+    it('leaves panelRole undefined when the button has no panelId', () => {
+      const result = render(baseBtn)
+      expect(result.props.panelRole).toBeUndefined()
+    })
+
+    it('leaves panelRole undefined when the target panel has no config at this breakpoint', () => {
+      const result = render({ ...baseBtn, panelId: 'missing' })
+      expect(result.props.panelRole).toBeUndefined()
+    })
+
     it('uses empty object fallback for missing breakpoint config', () => {
       const result = render(baseBtn, { ...appState, breakpoint: 'mobile' })
       expect(result.props.showLabel).toBe(true)

--- a/src/utils/getPanelRole.js
+++ b/src/utils/getPanelRole.js
@@ -1,0 +1,22 @@
+// Shared panel dialog/modality classification, used by Panel.jsx (to render the panel's
+// own role/aria-modal) and MapButton.jsx (to decide a trigger button's aria-haspopup) so
+// the two can't drift apart.
+
+// WCAG requires a modal to always be dismissible, so modal:true forces it regardless of config.
+export const classifyPanel = (bpConfig) => {
+  const isModal = bpConfig.modal === true
+  const isAside = bpConfig.slot === 'side' && bpConfig.open && !isModal
+  const isDismissible = isModal || bpConfig.dismissible !== false
+  const isDialog = !isAside && isDismissible
+  return { isModal, isAside, isDismissible, isDialog }
+}
+
+export const getPanelRole = ({ isDialog, isDismissible }) => {
+  if (isDialog) {
+    return 'dialog'
+  }
+  if (isDismissible) {
+    return 'complementary'
+  }
+  return 'region'
+}

--- a/src/utils/getPanelRole.test.js
+++ b/src/utils/getPanelRole.test.js
@@ -1,0 +1,56 @@
+import { classifyPanel, getPanelRole } from './getPanelRole.js'
+
+describe('classifyPanel', () => {
+  it('is a dialog when dismissible and not a persistent side aside', () => {
+    expect(classifyPanel({ slot: 'right-top', open: false })).toMatchObject({
+      isModal: false,
+      isAside: false,
+      isDismissible: true,
+      isDialog: true
+    })
+  })
+
+  it('is an aside (not a dialog) for a persistently open side panel', () => {
+    expect(classifyPanel({ slot: 'side', open: true })).toMatchObject({
+      isAside: true,
+      isDialog: false
+    })
+  })
+
+  it('is never an aside when modal, even in the side slot', () => {
+    expect(classifyPanel({ slot: 'side', open: true, modal: true })).toMatchObject({
+      isModal: true,
+      isAside: false,
+      isDismissible: true,
+      isDialog: true
+    })
+  })
+
+  it('treats dismissible: false as non-dismissible unless modal forces it', () => {
+    expect(classifyPanel({ slot: 'right-top', open: false, dismissible: false })).toMatchObject({
+      isDismissible: false,
+      isDialog: false
+    })
+  })
+
+  it('modal forces dismissible regardless of an explicit dismissible: false', () => {
+    expect(classifyPanel({ slot: 'right-top', open: false, dismissible: false, modal: true })).toMatchObject({
+      isDismissible: true,
+      isDialog: true
+    })
+  })
+})
+
+describe('getPanelRole', () => {
+  it('returns dialog when isDialog', () => {
+    expect(getPanelRole({ isDialog: true, isDismissible: true })).toBe('dialog')
+  })
+
+  it('returns complementary when dismissible but not a dialog', () => {
+    expect(getPanelRole({ isDialog: false, isDismissible: true })).toBe('complementary')
+  })
+
+  it('returns region when neither a dialog nor dismissible', () => {
+    expect(getPanelRole({ isDialog: false, isDismissible: false })).toBe('region')
+  })
+})


### PR DESCRIPTION
Extends aria haspopup to a map button where any controlled element is of a popup type. Also adds aria-expanded to the search button. And fixes the modal panel position when button slot is used.