### PR TITLE
Map features roving tabindex

### DIFF
--- a/demo/DemoMapSelectFeature.js
+++ b/demo/DemoMapSelectFeature.js
@@ -17,6 +17,7 @@ const parcelsDataset = {
   geojson,
   minZoom: 10,
   maxZoom: 24,
+  showInMenu: true,
   style: {
     fill: 'rgba(29, 112, 184, 0.1)',
     stroke: '#1d70b8',

--- a/demo/DemoMapSelectFeature.js
+++ b/demo/DemoMapSelectFeature.js
@@ -17,7 +17,6 @@ const parcelsDataset = {
   geojson,
   minZoom: 10,
   maxZoom: 24,
-  showInMenu: true,
   style: {
     fill: 'rgba(29, 112, 184, 0.1)',
     stroke: '#1d70b8',
@@ -59,7 +58,7 @@ function MapInner () {
         interactionModes: ['selectFeature'],
         deselectOnClickOutside: true,
         layers: [
-          { layerId: 'field-parcels', idProperty: 'name' }
+          { layerId: 'field-parcels', idProperty: 'name', labelProperty: 'name' }
         ]
       })
 

--- a/src/App/components/Viewport/Features.jsx
+++ b/src/App/components/Viewport/Features.jsx
@@ -1,29 +1,35 @@
 import React, { forwardRef } from 'react'
 import { useConfig } from '../../store/configContext.js'
 
-export const Features = forwardRef(({ activeFeatureId, selectedIds = [], multiselectable = false, items = [], onFocus, onBlur }, ref) => {
+export const Features = forwardRef(({ activeFeatureId, tabbableId, selectedIds = [], multiselectable = false, items = [], onFocus, onBlur, onSelectItem }, ref) => {
   const { id } = useConfig()
   const hasItems = items.length > 0
+  // Roving tabindex: exactly one option is a Tab stop at a time (the focused item while the
+  // list has real focus, otherwise the resting entry position) — see useFeatureFocus.js.
+  const currentId = activeFeatureId ?? tabbableId
   return (
     <ul // NOSONAR: role='listbox' is correct for custom composite widget; native <select> cannot host SVG marker elements
       id={`${id}-features`}
       ref={ref}
       role='listbox' // NOSONAR
-      tabIndex={hasItems ? '0' : '-1'}
       aria-hidden={hasItems ? undefined : true}
       aria-label='Map features'
       aria-describedby={`${id}-keyboard-desc`}
       aria-multiselectable={multiselectable || undefined}
-      aria-activedescendant={activeFeatureId ? `${id}-feature-${activeFeatureId}` : undefined}
       className='im-c-features'
       onFocus={onFocus}
       onBlur={onBlur}
     >
       {items.map(item => (
-        <li // NOSONAR: role='option' overrides implicit listitem; this is the correct ARIA listbox child pattern
+        <li // NOSONAR: role='option' overrides implicit listitem; this is the correct ARIA listbox child pattern.
+          // tabIndex/onClick make each option a real, independently focusable and activatable
+          // control — required so touch screen readers and voice control can reach and operate
+          // it directly, not just app-managed keyboard-arrow navigation.
           key={item.id} id={`${id}-feature-${item.id}`} role='option' // NOSONAR
           data-id={item.id}
+          tabIndex={item.id === currentId ? 0 : -1}
           aria-selected={selectedIds.includes(item.id)}
+          onClick={() => onSelectItem?.(item.id)}
         >
           {item.label}
         </li>

--- a/src/App/components/Viewport/Features.module.scss
+++ b/src/App/components/Viewport/Features.module.scss
@@ -16,10 +16,6 @@
     $is-inset: true
   );
 
-  &[data-focus-visible="true"][aria-activedescendant]::after {
-    opacity: 0;
-  }
-
   [role="option"] {
     position: absolute;
     width: 1px;
@@ -27,5 +23,9 @@
     overflow: hidden;
     clip-path: inset(50%);
     white-space: nowrap;
+    // Roving tabindex moves real focus (and click activation) onto individual options, so they
+    // need pointer events re-enabled — overridden off .im-c-features's pointer-events: none,
+    // which otherwise lets mouse interaction pass through to the map everywhere else.
+    pointer-events: auto;
   }
 }

--- a/src/App/components/Viewport/Features.test.jsx
+++ b/src/App/components/Viewport/Features.test.jsx
@@ -168,7 +168,7 @@ describe('Features + useFeatureFocus — roving tabindex real focus events', () 
     const { container } = render(<RovingHarness eventBus={eb} />)
     act(() => container.querySelector('[data-id="f1"]').focus())
     eb.emit.mockClear()
-    act(() => { fireEvent.keyDown(container.querySelector(LISTBOX), { key: 'ArrowDown' }) }) // NOSONAR
+    fireEvent.keyDown(container.querySelector(LISTBOX), { key: 'ArrowDown' }) // NOSONAR
     expect(eb.emit).toHaveBeenCalledTimes(1)
     expect(eb.emit).toHaveBeenCalledWith('map:setactivefeature', { id: 'f2' })
   })
@@ -177,7 +177,7 @@ describe('Features + useFeatureFocus — roving tabindex real focus events', () 
     const eb = { on: jest.fn(), off: jest.fn(), emit: jest.fn() }
     const { container } = render(<RovingHarness eventBus={eb} />)
     act(() => container.querySelector('[data-id="f1"]').focus())
-    act(() => { fireEvent.keyDown(container.querySelector(LISTBOX), { key: 'ArrowDown' }) }) // NOSONAR
+    fireEvent.keyDown(container.querySelector(LISTBOX), { key: 'ArrowDown' }) // NOSONAR
     expect(document.activeElement.dataset.id).toBe('f2')
   })
 
@@ -206,8 +206,8 @@ describe('Features + useFeatureFocus — roving tabindex real focus events', () 
     const { container } = render(<RovingHarness eventBus={eb} />)
     act(() => container.querySelector('[data-id="f1"]').focus())
     const listbox = container.querySelector(LISTBOX)
-    act(() => { fireEvent.keyDown(listbox, { key: 'ArrowDown' }) }) // NOSONAR — moves to f2
-    act(() => { fireEvent.keyDown(listbox, { key: 'Enter' }) })
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' }) // NOSONAR — moves to f2
+    fireEvent.keyDown(listbox, { key: 'Enter' })
     const options = container.querySelectorAll(OPTION)
     expect(options[0]).toHaveAttribute(ARIA_SELECTED, 'false') // f1 — must not be the one selected
     expect(options[1]).toHaveAttribute(ARIA_SELECTED, 'true') // f2 — the one actually focused
@@ -218,9 +218,9 @@ describe('Features + useFeatureFocus — roving tabindex real focus events', () 
     const { container } = render(<RovingHarness eventBus={eb} />)
     act(() => container.querySelector('[data-id="f1"]').focus())
     const listbox = container.querySelector(LISTBOX)
-    act(() => { fireEvent.keyDown(listbox, { key: 'ArrowDown' }) }) // NOSONAR — f1 -> f2
-    act(() => { fireEvent.keyDown(listbox, { key: 'Enter' }) }) // select f2
-    act(() => { fireEvent.keyDown(listbox, { key: 'ArrowUp' }) }) // f2 -> f1
+    fireEvent.keyDown(listbox, { key: 'ArrowDown' }) // NOSONAR — f1 -> f2
+    fireEvent.keyDown(listbox, { key: 'Enter' }) // select f2
+    fireEvent.keyDown(listbox, { key: 'ArrowUp' }) // f2 -> f1
     expect(document.activeElement.dataset.id).toBe('f1')
     expect(container.querySelectorAll(OPTION)[0].tabIndex).toBe(0)
   })

--- a/src/App/components/Viewport/Features.test.jsx
+++ b/src/App/components/Viewport/Features.test.jsx
@@ -1,6 +1,7 @@
-import React from 'react'
-import { render, fireEvent } from '@testing-library/react'
+import React, { useRef } from 'react'
+import { render, fireEvent, act } from '@testing-library/react'
 import { Features } from './Features.jsx'
+import { useFeatureFocus } from '../../hooks/useFeatureFocus.js'
 import { useConfig } from '../../store/configContext.js'
 
 jest.mock('../../store/configContext.js', () => ({ useConfig: jest.fn() }))
@@ -65,14 +66,18 @@ describe('Features — rendering', () => {
     expect(options[1]).toHaveAttribute(ARIA_SELECTED, 'false')
   })
 
-  it('sets aria-activedescendant to the option element id when activeFeatureId is provided', () => {
+  it('gives the active item tabIndex 0 and every other item tabIndex -1 (roving tabindex)', () => {
     const { container } = render(<Features items={ITEMS} activeFeatureId='f2' />)
-    expect(container.querySelector(LISTBOX).getAttribute('aria-activedescendant')).toBe('test-app-feature-f2') // NOSONAR
+    const options = container.querySelectorAll(OPTION)
+    expect(options[0].getAttribute('tabIndex')).toBe('-1')
+    expect(options[1].getAttribute('tabIndex')).toBe('0')
   })
 
-  it('omits aria-activedescendant when activeFeatureId is absent', () => {
-    const { container } = render(<Features items={ITEMS} />)
-    expect(container.querySelector(LISTBOX).getAttribute('aria-activedescendant')).toBeNull() // NOSONAR
+  it('falls back to tabbableId for roving tabindex when activeFeatureId is absent', () => {
+    const { container } = render(<Features items={ITEMS} tabbableId='f1' />)
+    const options = container.querySelectorAll(OPTION)
+    expect(options[0].getAttribute('tabIndex')).toBe('0')
+    expect(options[1].getAttribute('tabIndex')).toBe('-1')
   })
 
   it('sets aria-multiselectable when multiselectable is true', () => {
@@ -85,18 +90,17 @@ describe('Features — rendering', () => {
     expect(container.querySelector(LISTBOX).getAttribute('aria-multiselectable')).toBeNull() // NOSONAR
   })
 
-  it('is tabIndex 0 and not aria-hidden when items are present', () => {
+  it('is not aria-hidden when items are present', () => {
     const { container } = render(<Features items={ITEMS} />)
     const ul = container.querySelector(LISTBOX) // NOSONAR
-    expect(ul.getAttribute('tabIndex')).toBe('0')
     expect(ul.getAttribute('aria-hidden')).toBeNull()
   })
 
-  it('is tabIndex -1 and aria-hidden when items is empty', () => {
+  it('is aria-hidden and has no options when items is empty', () => {
     const { container } = render(<Features />)
     const ul = container.querySelector(LISTBOX) // NOSONAR
-    expect(ul.getAttribute('tabIndex')).toBe('-1')
     expect(ul.getAttribute('aria-hidden')).toBe('true')
+    expect(container.querySelectorAll(OPTION)).toHaveLength(0) // NOSONAR
   })
 
   it('sets aria-describedby to the shared hints container id', () => {
@@ -120,5 +124,130 @@ describe('Features — interactions', () => {
     const { container } = render(<Features onBlur={onBlur} />)
     fireEvent.blur(container.querySelector(LISTBOX)) // NOSONAR
     expect(onBlur).toHaveBeenCalled()
+  })
+
+  it('calls onSelectItem with the clicked item id', () => {
+    const onSelectItem = jest.fn()
+    const { container } = render(<Features items={ITEMS} onSelectItem={onSelectItem} />)
+    fireEvent.click(container.querySelectorAll(OPTION)[1]) // NOSONAR
+    expect(onSelectItem).toHaveBeenCalledWith('f2')
+  })
+
+  it('does not throw on click when onSelectItem is not provided', () => {
+    const { container } = render(<Features items={ITEMS} />)
+    expect(() => fireEvent.click(container.querySelectorAll(OPTION)[0])).not.toThrow() // NOSONAR
+  })
+})
+
+// ─── Features + useFeatureFocus — roving tabindex wired together for real ────
+//
+// The tests above exercise Features in isolation (mocked onFocus/onBlur), and
+// useFeatureFocus.test.js exercises the hook in isolation (onFocus/onBlur called
+// directly, not via real DOM events). Neither can catch a bug where moving real focus
+// between sibling options — which roving tabindex does on every arrow key — fires a
+// genuine native focusin that bubbles up and re-triggers React's onFocus on the <ul>.
+// Only rendering both together with real (unmocked) focus exercises that bubbling path.
+
+const RovingHarness = ({ eventBus }) => {
+  const viewportRef = useRef(document.createElement('div'))
+  const featuresRef = useRef(null)
+  const { activeFeatureId, tabbableId, selectedIds, onFocus, onBlur, selectItem } = useFeatureFocus({
+    viewportRef, featuresRef, items: ITEMS, eventBus, hints: { subscribe: () => () => {}, dismiss: () => {} }
+  })
+  return (
+    <Features
+      ref={featuresRef} activeFeatureId={activeFeatureId} tabbableId={tabbableId} selectedIds={selectedIds}
+      items={ITEMS} onFocus={onFocus} onBlur={onBlur} onSelectItem={selectItem}
+    />
+  )
+}
+
+describe('Features + useFeatureFocus — roving tabindex real focus events', () => {
+  it('emits map:setactivefeature exactly once when arrowing to the next option', () => {
+    const eb = { on: jest.fn(), off: jest.fn(), emit: jest.fn() }
+    const { container } = render(<RovingHarness eventBus={eb} />)
+    act(() => container.querySelector('[data-id="f1"]').focus())
+    eb.emit.mockClear()
+    act(() => { fireEvent.keyDown(container.querySelector(LISTBOX), { key: 'ArrowDown' }) }) // NOSONAR
+    expect(eb.emit).toHaveBeenCalledTimes(1)
+    expect(eb.emit).toHaveBeenCalledWith('map:setactivefeature', { id: 'f2' })
+  })
+
+  it('moves real DOM focus to the next option on ArrowDown', () => {
+    const eb = { on: jest.fn(), off: jest.fn(), emit: jest.fn() }
+    const { container } = render(<RovingHarness eventBus={eb} />)
+    act(() => container.querySelector('[data-id="f1"]').focus())
+    act(() => { fireEvent.keyDown(container.querySelector(LISTBOX), { key: 'ArrowDown' }) }) // NOSONAR
+    expect(document.activeElement.dataset.id).toBe('f2')
+  })
+
+  // A real pub/sub bus, with a minimal fake "interact plugin" listening on it — mirroring what
+  // useMapItemList.js actually does: track the last map:setactivefeature id, and on
+  // map:selectfeature, mark THAT id selected and fire interact:selectionchange back. This is
+  // the closest reproduction of the real reported bug: Enter only ever selecting the first item
+  // because every arrow move was clobbering the active id back to a stale value.
+  const makeFakeInteractBus = () => {
+    const listeners = {}
+    let lastActiveId = null
+    const bus = {
+      on: (event, fn) => { (listeners[event] ??= []).push(fn) },
+      off: (event, fn) => { listeners[event] = (listeners[event] ?? []).filter(f => f !== fn) },
+      emit: (event, payload) => { (listeners[event] ?? []).forEach(fn => fn(payload)) }
+    }
+    bus.on('map:setactivefeature', ({ id }) => { lastActiveId = id })
+    bus.on('map:selectfeature', () => {
+      bus.emit('interact:selectionchange', { selectedMarkers: lastActiveId ? [lastActiveId] : [] })
+    })
+    return bus
+  }
+
+  it('selects the item that is actually focused, not the first item, after navigating and pressing Enter', () => {
+    const eb = makeFakeInteractBus()
+    const { container } = render(<RovingHarness eventBus={eb} />)
+    act(() => container.querySelector('[data-id="f1"]').focus())
+    const listbox = container.querySelector(LISTBOX)
+    act(() => { fireEvent.keyDown(listbox, { key: 'ArrowDown' }) }) // NOSONAR — moves to f2
+    act(() => { fireEvent.keyDown(listbox, { key: 'Enter' }) })
+    const options = container.querySelectorAll(OPTION)
+    expect(options[0]).toHaveAttribute(ARIA_SELECTED, 'false') // f1 — must not be the one selected
+    expect(options[1]).toHaveAttribute(ARIA_SELECTED, 'true') // f2 — the one actually focused
+  })
+
+  it('keeps navigating correctly after a selection (does not get stuck reverting to the first item)', () => {
+    const eb = makeFakeInteractBus()
+    const { container } = render(<RovingHarness eventBus={eb} />)
+    act(() => container.querySelector('[data-id="f1"]').focus())
+    const listbox = container.querySelector(LISTBOX)
+    act(() => { fireEvent.keyDown(listbox, { key: 'ArrowDown' }) }) // NOSONAR — f1 -> f2
+    act(() => { fireEvent.keyDown(listbox, { key: 'Enter' }) }) // select f2
+    act(() => { fireEvent.keyDown(listbox, { key: 'ArrowUp' }) }) // f2 -> f1
+    expect(document.activeElement.dataset.id).toBe('f1')
+    expect(container.querySelectorAll(OPTION)[0].tabIndex).toBe(0)
+  })
+
+  it('selecting a marker on the map does not move the roving tabindex position — only aria-selected changes', () => {
+    const eb = makeFakeInteractBus()
+    const { container } = render(<RovingHarness eventBus={eb} />)
+    // Simulates repeatedly clicking a single marker on the map — never touches the list at all.
+    act(() => { eb.emit('interact:selectionchange', { selectedMarkers: ['f1'] }) })
+    act(() => { eb.emit('interact:selectionchange', { selectedMarkers: ['f2'] }) })
+    const options = container.querySelectorAll(OPTION)
+    expect(options[0].tabIndex).toBe(0) // f1 — the structural first item, unmoved
+    expect(options[1].tabIndex).toBe(-1)
+    expect(options[0]).toHaveAttribute(ARIA_SELECTED, 'false')
+    expect(options[1]).toHaveAttribute(ARIA_SELECTED, 'true') // only this changed
+  })
+
+  it('moves real focus to match the selected item when Tab lands somewhere else', () => {
+    const eb = makeFakeInteractBus()
+    const { container } = render(<RovingHarness eventBus={eb} />)
+    // f2 selected via a map click before any keyboard interaction — tabbableId stays on the
+    // structural first item (f1), so Tab lands there first.
+    act(() => { eb.emit('interact:selectionchange', { selectedMarkers: ['f2'] }) })
+    expect(container.querySelectorAll(OPTION)[0].tabIndex).toBe(0) // Tab will land on f1
+    act(() => container.querySelector('[data-id="f1"]').focus()) // simulates the Tab press
+    // onFocus resolves to the selected item (f2) and must move real focus there to match —
+    // otherwise the list's own focus/announcement would disagree with what the map highlights.
+    expect(document.activeElement.dataset.id).toBe('f2')
   })
 })

--- a/src/App/components/Viewport/Viewport.jsx
+++ b/src/App/components/Viewport/Viewport.jsx
@@ -27,7 +27,7 @@ export const Viewport = () => {
   const featuresRef = useRef(null)
 
   const { items: featureItems, multiselectable } = useFeatureItems(eventBus)
-  const { activeFeatureId, selectedIds, onFocus: handleFeaturesFocus, onBlur: handleFeaturesBlur } = useFeatureFocus({ viewportRef: layoutRefs.viewportRef, featuresRef, items: featureItems, eventBus, hints })
+  const { activeFeatureId, tabbableId, selectedIds, onFocus: handleFeaturesFocus, onBlur: handleFeaturesBlur, selectItem } = useFeatureFocus({ viewportRef: layoutRefs.viewportRef, featuresRef, items: featureItems, eventBus, hints })
 
   useEffect(() => {
     const handler = () => dispatch({ type: 'SET_LISTBOX_ACTIVE' })
@@ -94,7 +94,7 @@ export const Viewport = () => {
           <Markers />
         </div>
       </div>
-      <Features ref={featuresRef} activeFeatureId={activeFeatureId} selectedIds={selectedIds} multiselectable={multiselectable} items={featureItems} onFocus={onFeaturesFocus} onBlur={onFeaturesBlur} />
+      <Features ref={featuresRef} activeFeatureId={activeFeatureId} tabbableId={tabbableId} selectedIds={selectedIds} multiselectable={multiselectable} items={featureItems} onFocus={onFeaturesFocus} onBlur={onFeaturesBlur} onSelectItem={selectItem} />
     </>
   )
 }

--- a/src/App/hooks/useFeatureFocus.js
+++ b/src/App/hooks/useFeatureFocus.js
@@ -5,6 +5,12 @@ const getNavigatedId = (id, key, items) => {
   if (!items.length) {
     return id
   }
+  if (key === 'Home') {
+    return items[0].id
+  }
+  if (key === 'End') {
+    return items[items.length - 1].id
+  }
   const idx = items.findIndex(item => item.id === id)
   if (key === 'ArrowDown') {
     return idx === -1 ? items[0].id : items[Math.min(idx + 1, items.length - 1)].id
@@ -24,10 +30,25 @@ const resolveEntryId = (items, lastActiveId, selectedIds) => {
   return items[0].id
 }
 
+// Roving tabindex: moves real focus to the option matching id, found via data-id (avoids
+// CSS-escaping issues a querySelector would have with arbitrary ids). Flags
+// isInternalFocusMoveRef around the .focus() call so onFocus/onBlur can ignore this as an
+// internal move, not a real widget entry/exit — event.relatedTarget can't be used for that:
+// preact/compat (react is aliased to it in this app's build) doesn't populate it on synthetic
+// focus/blur events, so it's silently unreliable outside tests (real React + jsdom).
+const focusOption = (listboxEl, id, isInternalFocusMoveRef) => {
+  const el = Array.from(listboxEl?.children ?? []).find(li => li.dataset.id === String(id))
+  if (!el) {
+    return
+  }
+  isInternalFocusMoveRef.current = true
+  el.focus({ preventScroll: true })
+  isInternalFocusMoveRef.current = false
+}
+
 /**
  * Keeps local selectedIds in sync with interact:selectionchange, and mirrors
- * MAP_SET_ACTIVE_FEATURE back into React state so aria-activedescendant stays current.
- * Also tracks the last non-null active id so it can be restored on re-focus.
+ * MAP_SET_ACTIVE_FEATURE back into React state so the roving tabindex position stays current.
  */
 function useEventBusListeners ({ eventBus, lastActiveIdRef, setActiveFeatureId, setSelectedIds }) {
   useEffect(() => {
@@ -53,12 +74,10 @@ function useEventBusListeners ({ eventBus, lastActiveIdRef, setActiveFeatureId, 
 }
 
 /**
- * Revalidates aria-activedescendant when the item list changes while the listbox is focused.
- * If the current active item is no longer in the list (e.g. panned off screen), picks a new one
- * using ARIA priority order: first selected → last active position → first item.
- * Reads eventBus and selectedIds via refs to avoid spurious re-runs on selection change.
+ * Re-picks the active item (ARIA priority order) when it drops out of the item list while
+ * focused — e.g. panned off screen — and moves real focus to it.
  */
-function useItemsRevalidation ({ items, eventBus, isFocusedRef, lastActiveIdRef, activeFeatureIdRef, selectedIdsRef, setActiveFeatureId }) {
+function useItemsRevalidation ({ items, eventBus, isFocusedRef, featuresRef, isInternalFocusMoveRef, lastActiveIdRef, activeFeatureIdRef, selectedIdsRef, setActiveFeatureId }) {
   useEffect(() => {
     if (!isFocusedRef.current) {
       return
@@ -75,16 +94,18 @@ function useItemsRevalidation ({ items, eventBus, isFocusedRef, lastActiveIdRef,
     lastActiveIdRef.current = nextId
     setActiveFeatureId(nextId)
     eventBus?.emit(EVENTS.MAP_SET_ACTIVE_FEATURE, { id: nextId })
+    focusOption(featuresRef.current, nextId, isInternalFocusMoveRef)
   }, [items]) // NOSONAR — eventBus/selectedIds consumed via refs to avoid spurious re-runs on selection change
 }
 
 /**
  * Attaches a keydown listener to the listbox element for ARIA keyboard navigation:
- * - ArrowUp/ArrowDown — move the active item, emitting MAP_SET_ACTIVE_FEATURE
+ * - ArrowUp/ArrowDown — move the active item, moving real focus to it (roving tabindex)
+ * - Home/End — jump the active item to the first/last option
  * - Enter/Space — confirm selection, emitting MAP_SELECT_FEATURE
  * - Escape — return focus to the map viewport
  */
-function useKeyboardNavigation ({ featuresRef, viewportRef, items, eventBus, activeFeatureIdRef, lastActiveIdRef, setActiveFeatureId, hints, currentHintRef }) {
+function useKeyboardNavigation ({ featuresRef, viewportRef, items, eventBus, activeFeatureIdRef, lastActiveIdRef, setActiveFeatureId, isInternalFocusMoveRef, hints, currentHintRef }) {
   useEffect(() => {
     const listboxEl = featuresRef.current
     if (!listboxEl) {
@@ -99,13 +120,14 @@ function useKeyboardNavigation ({ featuresRef, viewportRef, items, eventBus, act
         } else {
           viewportRef.current?.focus()
         }
-      } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      } else if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Home' || event.key === 'End') {
         event.preventDefault()
         event.stopPropagation()
         const newId = getNavigatedId(activeFeatureIdRef.current, event.key, items)
         lastActiveIdRef.current = newId
         setActiveFeatureId(newId)
         eventBus?.emit(EVENTS.MAP_SET_ACTIVE_FEATURE, { id: newId })
+        focusOption(listboxEl, newId, isInternalFocusMoveRef)
       } else if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault()
         event.stopPropagation()
@@ -120,9 +142,8 @@ function useKeyboardNavigation ({ featuresRef, viewportRef, items, eventBus, act
 }
 
 /**
- * Clears listbox focus whenever the user interacts with the map via pointer (mouse or touch).
- * Any pointerdown outside the listbox element moves focus to the viewport, removing the
- * visible focus ring from the listbox without dropping focus to an unknown location.
+ * Returns focus to the viewport when the user interacts with the map via pointer while the
+ * listbox is focused — clears its focus ring without dropping focus to nowhere.
  */
 function useMapInteractionBlur ({ viewportRef, featuresRef, isFocusedRef }) {
   useEffect(() => {
@@ -141,18 +162,12 @@ function useMapInteractionBlur ({ viewportRef, featuresRef, isFocusedRef }) {
 }
 
 /**
- * Manages ARIA listbox focus state for the keyboard-accessible feature list.
- *
- * On focus, sets aria-activedescendant following ARIA priority order:
- *   1. First selected item (if any)
- *   2. Last active position (if still in the list)
- *   3. First item (fallback)
- *
- * On blur, clears the active descendant. Revalidates automatically when the item list
- * changes (e.g. after a map pan) so the active id never points to a stale item.
+ * Manages roving-tabindex focus state for the keyboard-accessible feature list. On focus, sets
+ * activeFeatureId via ARIA priority order (see resolveEntryId); on blur, clears it. Revalidates
+ * when the item list changes (e.g. after a map pan) so it never points to a stale item.
  *
  * @param {{ viewportRef: React.RefObject, featuresRef: React.RefObject, items: Array, eventBus: object }} params
- * @returns {{ activeFeatureId: string|null, selectedIds: string[], onFocus: Function, onBlur: Function }}
+ * @returns {{ activeFeatureId: string|null, tabbableId: string|null, selectedIds: string[], onFocus: Function, onBlur: Function, selectItem: Function }}
  */
 export function useFeatureFocus ({ viewportRef, featuresRef, items = [], eventBus, hints }) {
   const [activeFeatureId, setActiveFeatureId] = useState(null)
@@ -163,6 +178,7 @@ export function useFeatureFocus ({ viewportRef, featuresRef, items = [], eventBu
   const activeFeatureIdRef = useRef(null) // always-current for keydown closure
   const selectedIdsRef = useRef([]) // always-current for items-change effect
   const currentHintRef = useRef(null)
+  const isInternalFocusMoveRef = useRef(false) // true only while focusOption()'s own .focus() call is in flight
 
   useEffect(() => {
     return hints.subscribe((hint) => {
@@ -170,30 +186,72 @@ export function useFeatureFocus ({ viewportRef, featuresRef, items = [], eventBu
     })
   }, [hints])
 
-  useEffect(() => { activeFeatureIdRef.current = activeFeatureId }, [activeFeatureId])
-  useEffect(() => { selectedIdsRef.current = selectedIds }, [selectedIds])
+  // Always-current mirrors for values read from event-listener closures (not React re-renders) —
+  // assigned directly during render, same convention as useVisibleGeometry.js's latestRef.
+  activeFeatureIdRef.current = activeFeatureId
+  selectedIdsRef.current = selectedIds
 
   useEventBusListeners({ eventBus, lastActiveIdRef, setActiveFeatureId, setSelectedIds })
-  useItemsRevalidation({ items, eventBus, isFocusedRef, lastActiveIdRef, activeFeatureIdRef, selectedIdsRef, setActiveFeatureId })
-  useKeyboardNavigation({ featuresRef, viewportRef, items, eventBus, activeFeatureIdRef, lastActiveIdRef, setActiveFeatureId, hints, currentHintRef })
+  useItemsRevalidation({ items, eventBus, isFocusedRef, featuresRef, isInternalFocusMoveRef, lastActiveIdRef, activeFeatureIdRef, selectedIdsRef, setActiveFeatureId })
+  useKeyboardNavigation({ featuresRef, viewportRef, items, eventBus, activeFeatureIdRef, lastActiveIdRef, setActiveFeatureId, isInternalFocusMoveRef, hints, currentHintRef })
   useMapInteractionBlur({ viewportRef, featuresRef, isFocusedRef })
+
+  // Resting roving-tabindex position — where Tab lands before the list has ever had real focus.
+  // activeFeatureId takes priority once the list is actually focused. Deliberately never
+  // selection-driven (unlike onFocus's own resolution below) — sticks to the last established
+  // keyboard position, or the first item if there isn't one yet. "Prefer the selected item" is
+  // an onFocus-only concern (a real Tab-in); if it applied here too, any selection change made
+  // elsewhere (e.g. clicking a marker on the map, which never touches lastActiveIdRef) would
+  // keep relocating tabIndex to follow it, even though nothing about keyboard state changed.
+  let tabbableId = null
+  if (items.length) {
+    const hasEstablishedPosition = lastActiveIdRef.current && items.some(item => item.id === lastActiveIdRef.current)
+    tabbableId = hasEstablishedPosition ? lastActiveIdRef.current : items[0].id
+  }
 
   const onFocus = () => {
     isFocusedRef.current = true
+    // Ignore focus moving between sibling options (roving tabindex) — the keydown/selectItem
+    // path that moved it already resolved and emitted the correct id; re-resolving here would
+    // clobber that emit.
+    if (isInternalFocusMoveRef.current) {
+      return
+    }
     if (!items.length) {
       return
     }
+    // A real Tab-in always prefers a selected item over the remembered position (native listbox
+    // behaviour) — can't reuse tabbableId here, which deliberately does the opposite (sticks to
+    // the remembered position, ignoring selection) once one is established.
     const id = resolveEntryId(items, lastActiveIdRef.current, selectedIds)
     lastActiveIdRef.current = id
     setActiveFeatureId(id)
     eventBus?.emit(EVENTS.MAP_SET_ACTIVE_FEATURE, { id })
+    // Real focus may have landed on a different option than this resolves to — tabbableId (which
+    // decided where Tab lands) can legitimately disagree with resolveEntryId's own priority (e.g.
+    // Tab lands on the structural first item, but a different item is selected and takes
+    // priority here). Move real focus to match so it never disagrees with activeFeatureId.
+    focusOption(featuresRef.current, id, isInternalFocusMoveRef)
   }
 
   const onBlur = () => {
+    // Ignore focus moving between sibling options (roving tabindex) — not a real exit.
+    if (isInternalFocusMoveRef.current) {
+      return
+    }
     isFocusedRef.current = false
     setActiveFeatureId(null)
     eventBus?.emit(EVENTS.MAP_SET_ACTIVE_FEATURE, { id: null })
   }
 
-  return { activeFeatureId, selectedIds, onFocus, onBlur }
+  // Mirrors keyboard Enter/Space: make the clicked item active, focus it, then confirm selection.
+  const selectItem = (id) => {
+    lastActiveIdRef.current = id
+    setActiveFeatureId(id)
+    eventBus?.emit(EVENTS.MAP_SET_ACTIVE_FEATURE, { id })
+    focusOption(featuresRef.current, id, isInternalFocusMoveRef)
+    eventBus?.emit(EVENTS.MAP_SELECT_FEATURE)
+  }
+
+  return { activeFeatureId, tabbableId, selectedIds, onFocus, onBlur, selectItem }
 }

--- a/src/App/hooks/useFeatureFocus.test.js
+++ b/src/App/hooks/useFeatureFocus.test.js
@@ -154,6 +154,14 @@ describe('useFeatureFocus — onBlur', () => {
     const { result } = renderHook(() => useFeatureFocus({ ...makeRefs(), items: ITEMS }))
     expect(() => act(() => result.current.onBlur())).not.toThrow()
   })
+
+  // The "moving between sibling options shouldn't count as a real blur/focus" behavior is
+  // driven by an internal isInternalFocusMoveRef, set only while focusOption()'s own .focus()
+  // call is synchronously in flight — not observable by calling onFocus/onBlur directly here,
+  // since that requires a real DOM focus transition bubbling through React. See the
+  // "Features + useFeatureFocus — roving tabindex real focus events" suite in Features.test.jsx,
+  // which renders the real markup and is the only level this can be faithfully exercised at
+  // (and is where the regression this guards against was actually found).
 })
 
 // ─── useFeatureFocus — keydown listener lifecycle ────────────────────────────
@@ -344,6 +352,70 @@ describe('useFeatureFocus — ArrowUp navigation', () => {
     fireKey(el, 'ArrowUp')
     fireKey(el, 'ArrowUp')
     expect(result.current.activeFeatureId).toBe('a')
+    unmount(); el.remove()
+  })
+})
+
+// ─── useFeatureFocus — Home/End navigation ───────────────────────────────────
+
+describe('useFeatureFocus — Home/End navigation', () => {
+  const setup = () => {
+    const refs = makeRefs()
+    const el = refs.featuresRef.current
+    document.body.appendChild(el)
+    const { result, unmount } = renderHook(() => useFeatureFocus({ ...refs, items: ITEMS }))
+    return { result, el, unmount }
+  }
+
+  it('jumps to the first item on Home from anywhere in the list', () => {
+    const { result, el, unmount } = setup()
+    act(() => result.current.onFocus())
+    fireKey(el, 'ArrowDown')
+    fireKey(el, 'Home')
+    expect(result.current.activeFeatureId).toBe('a')
+    unmount(); el.remove()
+  })
+
+  it('jumps to the last item on End from anywhere in the list', () => {
+    const { result, el, unmount } = setup()
+    act(() => result.current.onFocus())
+    fireKey(el, 'End')
+    expect(result.current.activeFeatureId).toBe('c')
+    unmount(); el.remove()
+  })
+
+  it('does nothing when items is empty', () => {
+    const refs = makeRefs()
+    const el = refs.featuresRef.current
+    document.body.appendChild(el)
+    const { result, unmount } = renderHook(() => useFeatureFocus(refs))
+    fireKey(el, 'Home')
+    fireKey(el, 'End')
+    expect(result.current.activeFeatureId).toBeNull()
+    unmount(); el.remove()
+  })
+
+  it('stops propagation on Home/End so the viewport keyboard handler does not also handle it', () => {
+    const { el, unmount } = setup()
+    for (const key of ['Home', 'End']) {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      const stopSpy = jest.spyOn(event, 'stopPropagation')
+      act(() => el.dispatchEvent(event))
+      expect(stopSpy).toHaveBeenCalled()
+    }
+    unmount()
+  })
+
+  it('emits map:setactivefeature with the boundary id', () => {
+    const eb = makeEventBus()
+    const refs = makeRefs()
+    const el = refs.featuresRef.current
+    document.body.appendChild(el)
+    const { result, unmount } = renderHook(() => useFeatureFocus({ ...refs, items: ITEMS, eventBus: eb }))
+    act(() => result.current.onFocus())
+    eb.emit.mockClear()
+    fireKey(el, 'End')
+    expect(eb.emit).toHaveBeenCalledWith(SET_ACTIVE, { id: 'c' })
     unmount(); el.remove()
   })
 })
@@ -631,5 +703,100 @@ describe('useFeatureFocus — items change while focused', () => {
     expect(result.current.activeFeatureId).toBeNull()
     expect(eb.emit).toHaveBeenCalledWith('map:setactivefeature', { id: null })
     unmount()
+  })
+})
+
+// ─── useFeatureFocus — tabbableId (roving tabindex resting position) ─────────
+
+describe('useFeatureFocus — tabbableId', () => {
+  it('is null when items is empty', () => {
+    const { result } = renderHook(() => useFeatureFocus(makeRefs()))
+    expect(result.current.tabbableId).toBeNull()
+  })
+
+  it('defaults to the first item before the list has ever been focused', () => {
+    const { result } = renderHook(() => useFeatureFocus({ ...makeRefs(), items: ITEMS }))
+    expect(result.current.tabbableId).toBe('a')
+  })
+
+  // Unlike onFocus's own resolution, tabbableId deliberately ignores selection — "prefer the
+  // selected item" is a real-Tab-in-only concern. If tabbableId also preferred it, selecting a
+  // single marker by clicking it on the map (which never touches lastActiveIdRef) would relocate
+  // tabIndex to match it on every click.
+  it('is not influenced by a selection change before any position is established', () => {
+    const eb = makeEventBus()
+    const { result } = renderHook(() => useFeatureFocus({ ...makeRefs(), items: ITEMS, eventBus: eb }))
+    act(() => eb.trigger(SELECTION_CHANGE, { selectedFeatures: [{ featureId: 'b', layerId: 'roads' }] }))
+    expect(result.current.tabbableId).toBe('a')
+  })
+
+  it('does not chase a single item toggled selected/deselected purely via mouse clicks, with no keyboard interaction at all', () => {
+    const eb = makeEventBus()
+    const { result } = renderHook(() => useFeatureFocus({ ...makeRefs(), items: ITEMS, eventBus: eb }))
+    act(() => eb.trigger(SELECTION_CHANGE, { selectedMarkers: ['a'] }))
+    expect(result.current.tabbableId).toBe('a')
+    act(() => eb.trigger(SELECTION_CHANGE, { selectedMarkers: ['b'] })) // clicked a different marker
+    expect(result.current.tabbableId).toBe('a') // still the structural first item — never moved
+    act(() => eb.trigger(SELECTION_CHANGE, { selectedMarkers: ['c'] }))
+    expect(result.current.tabbableId).toBe('a')
+  })
+
+  it('stays on the established position when a selection change arrives from elsewhere (e.g. clicking a marker on the map)', () => {
+    const eb = makeEventBus()
+    const refs = makeRefs()
+    const el = refs.featuresRef.current
+    document.body.appendChild(el)
+    const { result, unmount } = renderHook(() => useFeatureFocus({ ...refs, items: ITEMS, eventBus: eb }))
+    act(() => result.current.onFocus()) // establishes position at 'a'
+    fireKey(el, 'ArrowDown') // establishes position at 'b'
+    act(() => result.current.onBlur())
+    // A selection made outside the list (e.g. a mouse click on a map marker) never touches
+    // lastActiveIdRef — it only changes selectedIds via interact:selectionchange.
+    act(() => eb.trigger(SELECTION_CHANGE, { selectedMarkers: ['c'] }))
+    expect(result.current.tabbableId).toBe('b') // stays put — does not jump to the newly-selected 'c'
+    unmount(); el.remove()
+  })
+})
+
+// ─── useFeatureFocus — selectItem (click / touch / voice-control activation) ─
+
+describe('useFeatureFocus — selectItem', () => {
+  afterEach(() => { document.body.innerHTML = '' })
+
+  it('sets activeFeatureId to the clicked item', () => {
+    const { result } = renderHook(() => useFeatureFocus({ ...makeRefs(), items: ITEMS }))
+    act(() => result.current.selectItem('b'))
+    expect(result.current.activeFeatureId).toBe('b')
+  })
+
+  it('emits map:setactivefeature then map:selectfeature for the clicked item', () => {
+    const eb = makeEventBus()
+    const { result } = renderHook(() => useFeatureFocus({ ...makeRefs(), items: ITEMS, eventBus: eb }))
+    act(() => result.current.selectItem('b'))
+    expect(eb.emit).toHaveBeenNthCalledWith(1, SET_ACTIVE, { id: 'b' })
+    expect(eb.emit).toHaveBeenNthCalledWith(2, SELECT)
+  })
+
+  it('moves real DOM focus to the clicked option', () => {
+    const refs = makeRefs()
+    const option = document.createElement('li')
+    option.dataset.id = 'b'
+    option.focus = jest.fn()
+    refs.featuresRef.current.appendChild(option)
+    const { result } = renderHook(() => useFeatureFocus({ ...refs, items: ITEMS }))
+    act(() => result.current.selectItem('b'))
+    expect(option.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('does not throw when eventBus is not provided', () => {
+    const { result } = renderHook(() => useFeatureFocus({ ...makeRefs(), items: ITEMS }))
+    expect(() => act(() => result.current.selectItem('b'))).not.toThrow()
+  })
+
+  it('does not throw when featuresRef.current is null (e.g. unmounted)', () => {
+    const refs = { ...makeRefs(), featuresRef: { current: null } }
+    const { result } = renderHook(() => useFeatureFocus({ ...refs, items: ITEMS }))
+    expect(() => act(() => result.current.selectItem('b'))).not.toThrow()
+    expect(result.current.activeFeatureId).toBe('b') // state still updates even though there's no element to focus
   })
 })


### PR DESCRIPTION
Swaps the aria active-descendant pattern with roving tabindex pattern for the map features list so that voice interfaces can also select features.