### PR TITLE
fix: classify OL layers by a layerType tag instead of instanceof

### DIFF
--- a/govuk-prototype-kit.config.json
+++ b/govuk-prototype-kit.config.json
@@ -65,6 +65,7 @@
     "/plugins/search/dist",
     "/plugins/draw/dist",
     "/providers/beta/open-names/dist",
+    "/providers/beta/openlayers/dist",
     "/plugins/datasets/dist",
     "/plugins/map-key/dist",
     "/plugins/menu/dist",

--- a/plugins/draw/src/adapters/openlayers/core/OLDrawManager.js
+++ b/plugins/draw/src/adapters/openlayers/core/OLDrawManager.js
@@ -49,6 +49,11 @@ export class OLDrawManager {
       zIndex: 100
     })
     this._layer.set('layerId', 'draw')
+    // Tagged rather than left to `instanceof VectorLayer` on the reading side — a UMD
+    // consumer loads the provider and this plugin as independently-bundled scripts, each
+    // with its own copy of ol, so a class reference from one bundle never matches an
+    // instance from another.
+    this._layer.set('layerType', 'vector')
     map.addLayer(this._layer)
   }
 

--- a/plugins/draw/src/adapters/openlayers/snap/snapEngine.js
+++ b/plugins/draw/src/adapters/openlayers/snap/snapEngine.js
@@ -1,6 +1,4 @@
 import { transform as projTransform } from 'ol/proj.js'
-import VectorLayer from 'ol/layer/Vector.js'
-import VectorTileLayer from 'ol/layer/VectorTile.js'
 import { testOLFeature, testRenderFeature, bestOf } from './snapGeometry.js'
 
 // VectorTile geometry is clipped to a rectangle (tile extent + buffer), producing fake
@@ -136,11 +134,15 @@ const pickVisibleCandidates = (best, candidates, context) => {
   return result
 }
 
-// Collected on each query — VectorTileLayers are replaced when the map style changes
+// Collected on each query — VectorTileLayers are replaced when the map style changes.
+// Classified by the `layerType` tag the provider sets at creation, not `instanceof
+// VectorTileLayer` — this adapter and the provider are independently-bundled scripts in
+// a UMD consumer, each with its own copy of ol, so a class reference from this bundle
+// never matches an instance the provider built.
 const getVTLayers = (map) => {
   const layers = []
   map.getLayers().forEach(l => {
-    if (l instanceof VectorTileLayer) { layers.push(l) }
+    if (l.get('layerType') === 'vectorTile') { layers.push(l) }
   })
   return layers
 }
@@ -155,7 +157,10 @@ export const createSnapEngine = (map, snapLayers = []) => {
     for (const entry of layers ?? []) {
       if (typeof entry === 'string') {
         vtLayerNames.add(entry)
-      } else if (entry instanceof VectorLayer) {
+      } else if (typeof entry?.getSource === 'function') {
+        // Duck-typed rather than `instanceof VectorLayer` — an entry here can be a live
+        // layer object a consumer built themselves with their own copy of ol, which would
+        // never satisfy an instanceof check against this bundle's own copy of the class.
         olLayers.push(entry)
       } else {
         // unsupported layer type — skip

--- a/plugins/draw/src/adapters/openlayers/snap/snapEngine.test.js
+++ b/plugins/draw/src/adapters/openlayers/snap/snapEngine.test.js
@@ -35,6 +35,7 @@ const renderFeature = (type, flat, ends = null, mapboxLayer = { id: 'boundaries'
 const setupVT = ({ features, withTileGrid = true, fillNeighbour = false }) => {
   const map = createEngineMap()
   const vtLayer = new VectorTileLayer({})
+  vtLayer.set('layerType', 'vectorTile') // mirrors the provider's own tagging in tileLayers.js
   if (withTileGrid) {
     jest.spyOn(vtLayer, 'getSource').mockReturnValue({ getTileGrid: () => tileGrid, getProjection: () => null })
   }

--- a/providers/beta/openlayers/src/utils/highlightFeatures.js
+++ b/providers/beta/openlayers/src/utils/highlightFeatures.js
@@ -1,4 +1,3 @@
-import VectorTileLayer from 'ol/layer/VectorTile.js'
 import VectorLayer from 'ol/layer/Vector.js'
 import VectorSource from 'ol/source/Vector.js'
 import Feature from 'ol/Feature.js'
@@ -17,6 +16,11 @@ const geoJsonFormat = new GeoJSON({ dataProjection: CRS, featureProjection: CRS 
 
 const HIGHLIGHT_MARKER = '_highlight'
 const HIGHLIGHT_Z = 999
+
+// Layers are classified by a `layerType` tag ('vector' | 'vectorTile') set at creation,
+// not `instanceof VectorLayer`/`VectorTileLayer` — a UMD consumer loads this provider and
+// other plugins (e.g. draw) as independently-bundled scripts, each with its own copy of
+// ol, so a class reference from this bundle never matches an instance built by another.
 
 const buildHighlightStyles = (styleEntry, isActive) => {
   if (!styleEntry) {
@@ -39,6 +43,13 @@ const buildHighlightStyles = (styleEntry, isActive) => {
 }
 
 const hasSymbolStyle = (properties) => !!(properties?.symbol || properties?.symbolSvgContent)
+
+const toStyleArray = (style) => {
+  if (!style) {
+    return []
+  }
+  return Array.isArray(style) ? style : [style]
+}
 
 // A drawn point renders as a real symbol icon, not Stroke/Fill, so its selected/active ring is
 // the active/selected variant of that same icon instead. Returns null (not []) for a
@@ -83,7 +94,7 @@ const buildFeatureKeyIndex = (features) => {
 
 const wrapVtLayers = (map, selectedKeys, activeKeys, idPropsMap, stylesMap) => {
   map.getLayers().forEach(layer => {
-    if (!(layer instanceof VectorTileLayer)) {
+    if (layer.get('layerType') !== 'vectorTile') {
       return
     }
 
@@ -124,8 +135,7 @@ const wrapVtLayers = (map, selectedKeys, activeKeys, idPropsMap, stylesMap) => {
         return base
       }
 
-      const baseArr = base ? (Array.isArray(base) ? base : [base]) : []
-      return [...baseArr, ...highlightStyles]
+      return [...toStyleArray(base), ...highlightStyles]
     })
     // setStyle() calls layer.changed() internally — no source.changed() needed
     // (source.changed() works but causes a visible flicker on selection)
@@ -148,6 +158,7 @@ const getOrCreateHighlightLayer = (map) => {
   if (!layer) {
     layer = new VectorLayer({ source: new VectorSource(), zIndex: HIGHLIGHT_Z + 2 })
     layer.set(HIGHLIGHT_MARKER, true)
+    layer.set('layerType', 'vector')
     map.addLayer(layer)
   }
   return layer
@@ -162,7 +173,7 @@ const getLiveProperties = (map, layerId, featureId) => {
   }
   let properties
   map.getLayers().forEach(l => {
-    if (properties || !(l instanceof VectorLayer) || l.get(HIGHLIGHT_MARKER) || l.get('layerId') !== layerId) {
+    if (properties || l.get('layerType') !== 'vector' || l.get(HIGHLIGHT_MARKER) || l.get('layerId') !== layerId) {
       return
     }
     const feature = l.getSource()?.getFeatureById(String(featureId))
@@ -180,12 +191,11 @@ const addVectorHighlights = (map, source, features, isActive, stylesMap) => {
     }
     const liveProperties = getLiveProperties(map, layerId, featureId)
     const styles = buildSymbolHighlightStyle(liveProperties, isActive) ?? buildHighlightStyles(stylesMap?.[layerId], isActive)
-    if (!styles.length) {
-      continue
+    if (styles.length) {
+      const olFeature = new Feature({ geometry: geoJsonFormat.readGeometry(geometry) })
+      olFeature.setStyle(styles)
+      source.addFeature(olFeature)
     }
-    const olFeature = new Feature({ geometry: geoJsonFormat.readGeometry(geometry) })
-    olFeature.setStyle(styles)
-    source.addFeature(olFeature)
   }
 }
 
@@ -206,6 +216,8 @@ const expandBoundsFromGeometry = (geometry, cb) => {
     coordinates.forEach(visitRing)
   } else if (type === 'MultiPolygon') {
     coordinates.forEach(poly => poly.forEach(visitRing))
+  } else {
+    // unsupported/unrecognised geometry type — nothing to expand bounds by
   }
 }
 
@@ -260,7 +272,7 @@ export const updateHighlightedFeatures = (map, selectedFeatures, activeFeatures,
   // Determine which layerIds belong to plain VectorLayers vs VT layers
   const vectorLayerIds = new Set()
   map.getLayers().forEach(l => {
-    if (l instanceof VectorLayer && !l.get(HIGHLIGHT_MARKER)) {
+    if (l.get('layerType') === 'vector' && !l.get(HIGHLIGHT_MARKER)) {
       const id = l.get('layerId')
       if (id) {
         vectorLayerIds.add(id)

--- a/providers/beta/openlayers/src/utils/highlightFeatures.test.js
+++ b/providers/beta/openlayers/src/utils/highlightFeatures.test.js
@@ -38,6 +38,7 @@ const drawLayer = (features = []) => {
   })
   const layer = new VectorLayer({ source })
   layer.set('layerId', 'draw')
+  layer.set('layerType', 'vector') // mirrors OLDrawManager.js's own tagging
   return layer
 }
 
@@ -170,6 +171,7 @@ describe('updateHighlightedFeatures', () => {
 describe('VectorTileLayer style-wrap (smoke test — pre-existing, undocumented path)', () => {
   test('does not throw when a VT layer is present alongside a draw VectorLayer', () => {
     const vt = new VectorTileLayer({})
+    vt.set('layerType', 'vectorTile')
     const map = createFakeMap([vt, drawLayer()])
     expect(() => updateHighlightedFeatures(map, [], [], {})).not.toThrow()
   })

--- a/providers/beta/openlayers/src/utils/hoverCursor.js
+++ b/providers/beta/openlayers/src/utils/hoverCursor.js
@@ -1,15 +1,16 @@
-import VectorTileLayer from 'ol/layer/VectorTile.js'
-import VectorLayer from 'ol/layer/Vector.js'
-
 const HIGHLIGHT_MARKER = '_highlight'
 const HIT_TOLERANCE = 8
 
+// Layers are classified by a `layerType` tag ('vector' | 'vectorTile') set at creation,
+// not `instanceof VectorLayer`/`VectorTileLayer` — a UMD consumer loads this provider and
+// other plugins (e.g. draw) as independently-bundled scripts, each with its own copy of
+// ol, so a class reference from this bundle never matches an instance built by another.
 const isInteractiveFeature = (feature, layer, layerSet) => {
-  if (layer instanceof VectorTileLayer) {
+  if (layer.get('layerType') === 'vectorTile') {
     const styleLayerId = feature.get('mapbox-layer')?.id
     return Boolean(styleLayerId && layerSet.has(styleLayerId))
   }
-  if (layer instanceof VectorLayer && !layer.get(HIGHLIGHT_MARKER)) {
+  if (layer.get('layerType') === 'vector' && !layer.get(HIGHLIGHT_MARKER)) {
     const layerId = layer.get('layerId')
     return Boolean(layerId && layerSet.has(layerId))
   }

--- a/providers/beta/openlayers/src/utils/hoverCursor.test.js
+++ b/providers/beta/openlayers/src/utils/hoverCursor.test.js
@@ -26,13 +26,14 @@ const makeVectorFeature = () => ({ get: () => undefined })
 
 const makeVTLayer = () => {
   const layer = new VectorTileLayer()
-  layer.get = () => undefined
+  layer.get = (key) => key === 'layerType' ? 'vectorTile' : undefined
   return layer
 }
 
 const makeVectorLayer = (layerId, isHighlight = false) => {
   const layer = new VectorLayer()
   layer.get = (key) => {
+    if (key === 'layerType') return 'vector'
     if (key === '_highlight') return isHighlight ? true : undefined
     if (key === 'layerId') return layerId
     return undefined

--- a/providers/beta/openlayers/src/utils/queryFeatures.js
+++ b/providers/beta/openlayers/src/utils/queryFeatures.js
@@ -1,5 +1,3 @@
-import VectorTileLayer from 'ol/layer/VectorTile.js'
-import VectorLayer from 'ol/layer/Vector.js'
 import GeoJSON from 'ol/format/GeoJSON.js'
 import TileState from 'ol/TileState.js'
 import { renderFeatureToGeoJSON } from './vtTileFragments.js'
@@ -7,6 +5,11 @@ import { renderFeatureToGeoJSON } from './vtTileFragments.js'
 const CRS = 'EPSG:27700'
 
 const geoJsonFormat = new GeoJSON({ dataProjection: CRS, featureProjection: CRS })
+
+// Layers are classified by a `layerType` tag ('vector' | 'vectorTile') set at creation,
+// not `instanceof VectorLayer`/`VectorTileLayer` — a UMD consumer loads this provider and
+// other plugins (e.g. draw) as independently-bundled scripts, each with its own copy of
+// ol, so a class reference from this bundle never matches an instance built by another.
 
 // Mirror MapLibre's fallback: use property hash when feature has no explicit MVT ID.
 // This deduplicates tile-split fragments that share the same properties.
@@ -32,7 +35,7 @@ export const queryFeatures = (map, point, options = {}) => {
   map.forEachFeatureAtPixel(
     pixel,
     (feature, layer) => {
-      if (layer instanceof VectorTileLayer) {
+      if (layer.get('layerType') === 'vectorTile') {
         const mapboxLayer = feature.get('mapbox-layer')
         const styleLayerId = mapboxLayer?.id
         // background-type layers have no features in MapLibre — skip to match behaviour
@@ -50,7 +53,7 @@ export const queryFeatures = (map, point, options = {}) => {
           geometry: renderFeatureToGeoJSON(feature),
           properties: feature.getProperties()
         })
-      } else if (layer instanceof VectorLayer) {
+      } else if (layer.get('layerType') === 'vector') {
         const layerId = layer.get('layerId')
         if (!layerId || layer.get('_highlight')) {
           return
@@ -98,7 +101,7 @@ export const getVisibleFeatures = (map, layerIds) => {
   const extent = map.getView().calculateExtent(map.getSize())
 
   map.getLayers().forEach(mapLayer => {
-    if (mapLayer instanceof VectorTileLayer) {
+    if (mapLayer.get('layerType') === 'vectorTile') {
       const sourceTiles = mapLayer.getSource()?.sourceTiles_
       if (!sourceTiles) {
         return
@@ -127,7 +130,7 @@ export const getVisibleFeatures = (map, layerIds) => {
           })
         })
       })
-    } else if (mapLayer instanceof VectorLayer) {
+    } else if (mapLayer.get('layerType') === 'vector') {
       const layerId = mapLayer.get('layerId')
       if (!layerId || !wanted.has(layerId) || mapLayer.get('_highlight')) {
         return

--- a/providers/beta/openlayers/src/utils/queryFeatures.test.js
+++ b/providers/beta/openlayers/src/utils/queryFeatures.test.js
@@ -24,7 +24,7 @@ const makeMap = (hits = []) => ({
   })
 })
 
-const makeVTLayer = () => Object.assign(new VectorTileLayer(), { get: () => undefined })
+const makeVTLayer = () => Object.assign(new VectorTileLayer(), { get: (key) => key === 'layerType' ? 'vectorTile' : undefined })
 
 const makeVTFeature = ({ id = undefined, styleLayerId = 'roads', type = 'fill', props = {} } = {}) => ({
   getId: () => id,
@@ -37,6 +37,7 @@ const makeVTFeature = ({ id = undefined, styleLayerId = 'roads', type = 'fill', 
 
 const makeVectorLayer = (layerId, isHighlight = false) => Object.assign(new VectorLayer(), {
   get: (key) => {
+    if (key === 'layerType') return 'vector'
     if (key === 'layerId') return layerId
     if (key === '_highlight') return isHighlight || undefined
     return undefined
@@ -170,7 +171,7 @@ describe('queryFeatures', () => {
 
   it('skips features from other layer types', () => {
     const feature = makeVectorFeature('f1')
-    const map = makeMap([[feature, {}]]) // plain object, not VectorTileLayer or VectorLayer
+    const map = makeMap([[feature, { get: () => undefined }]]) // untagged, not a vector/vectorTile layer
     expect(queryFeatures(map, { x: 0, y: 0 })).toEqual([])
   })
 
@@ -199,6 +200,7 @@ describe('getVisibleFeatures', () => {
   })
 
   const makeVTLayerWithTiles = (tiles) => Object.assign(new VectorTileLayer(), {
+    get: (key) => key === 'layerType' ? 'vectorTile' : undefined,
     getSource: () => ({ sourceTiles_: tiles })
   })
 
@@ -206,6 +208,7 @@ describe('getVisibleFeatures', () => {
     const source = { getFeaturesInExtent: jest.fn(() => features) }
     return Object.assign(new VectorLayer(), {
       get: (key) => {
+        if (key === 'layerType') return 'vector'
         if (key === 'layerId') return layerId
         if (key === '_highlight') return isHighlight || undefined
         return undefined
@@ -290,7 +293,7 @@ describe('getVisibleFeatures', () => {
   /* ------------------------------------------------------------------ */
 
   it('skips layers that are neither VectorTileLayer nor VectorLayer', () => {
-    expect(getVisibleFeatures(makeExtentMap([{}]), ['draw'])).toEqual([])
+    expect(getVisibleFeatures(makeExtentMap([{ get: () => undefined }]), ['draw'])).toEqual([])
   })
 
   it('returns results from both VT and Vector layers in one call', () => {

--- a/providers/beta/openlayers/src/utils/tileLayers.js
+++ b/providers/beta/openlayers/src/utils/tileLayers.js
@@ -139,6 +139,10 @@ export async function createVectorTileLayer (url, transformRequest, { renderMode
     tileGrid
   })
   const layer = new VectorTileLayer({ source, declutter: true, ...(renderMode && { renderMode }) })
+  // Tagged rather than left to `instanceof VectorTileLayer` — a UMD consumer loads this
+  // provider and other plugins as independently-bundled scripts, each with its own copy
+  // of ol, so a class reference from one bundle never matches an instance from another.
+  layer.set('layerType', 'vectorTile')
 
   stylefunction(layer, styleJson, sourceId, resolutions, spritesJson, sprite.pngUrl)
 
@@ -171,6 +175,7 @@ export async function createOGCVectorTileLayer (url, transformRequest, { renderM
   const tileGrid = new TileGrid({ resolutions, origin, tileSize })
   const source = new OGCVectorTile({ url: tilesUrl, format, tileGrid, projection: CRS })
   const layer = new VectorTileLayer({ source, declutter: true, ...(renderMode && { renderMode }) })
+  layer.set('layerType', 'vectorTile')
 
   stylefunction(layer, styleJson, sourceId, resolutions, spritesJson, sprite.pngUrl)
 

--- a/providers/beta/openlayers/src/utils/tileLayers.test.js
+++ b/providers/beta/openlayers/src/utils/tileLayers.test.js
@@ -14,7 +14,7 @@ const mockWMSSourceInstance = {}
 const mockTileLayerInstance = {}
 const mockVectorTileSourceInstance = {}
 const mockOGCVectorTileSourceInstance = { supportedMediaTypes: [] }
-const mockVectorTileLayerInstance = {}
+const mockVectorTileLayerInstance = { set: jest.fn() }
 const mockMVTInstance = { supportedMediaTypes: [] }
 
 jest.mock('ol/source/XYZ.js', () => ({ __esModule: true, default: jest.fn(() => mockSourceInstance) }))


### PR DESCRIPTION
fix: classify OL layers by a layerType tag instead of instanceof so click/hover/highlight/snap work across independently-bundled UMD packages