### PR TITLE
OpenLayers draw snapping fixed to avoid cross-bundle projection transform

### DIFF
--- a/plugins/draw/src/adapters/openlayers/snap/snapEngine.js
+++ b/plugins/draw/src/adapters/openlayers/snap/snapEngine.js
@@ -25,7 +25,14 @@ const buildTileBoundaryState = (layer, map) => {
 const getClipContext = (state, coord) => {
   if (!state) { return null }
   const { tileGrid, viewProj, sourceProj, zoom } = state
-  const toSource = (c) => c ? projTransform(c, viewProj, sourceProj) : null
+  // Same-code projections need no reprojection — skipping the call also avoids depending
+  // on ol/proj's registry having a transform for the pair, which can be missing when the
+  // draw plugin and the map provider ship as separate bundles each with their own ol/proj4.
+  const codeOf = (projection) => (typeof projection === 'string' ? projection : projection.getCode())
+  const toSource = (coordinate) => {
+    if (!coordinate) { return null }
+    return codeOf(sourceProj) === codeOf(viewProj) ? coordinate : projTransform(coordinate, viewProj, sourceProj)
+  }
   const anchor = toSource(coord)
   const tileCoord = tileGrid.getTileCoordForCoordAndZ(anchor, zoom)
   const extent = tileGrid.getTileCoordExtent(tileCoord)


### PR DESCRIPTION
## OpenLayers draw snapping fixed to avoid cross-bundle projection transform

**Problem:** With the draw plugin and OpenLayers provider loaded as separate bundles, enabling snapping threw `No transform available between EPSG:27700 and EPSG:27700` and broke vertex dragging in edit mode. Each bundle vendors its own private `ol/proj` registry, and only the provider's bundle registers `EPSG:27700` — the draw plugin's `snapEngine.js` calls `transform()` against its own separate, unregistered registry.

**Fix:** `snapEngine.js` now skips the `transform()` call when source and view projection codes already match, avoiding the cross-bundle registry dependency entirely.
